### PR TITLE
Pointing broken HawkNL link to internet archive

### DIFF
--- a/Example/Readme.txt
+++ b/Example/Readme.txt
@@ -6,7 +6,7 @@ The example socket implementation is outside the scope
 of the DIS implementation, but provided so that the
 testing is complete.  This socket implementation depends
 upon the HawkNL library.  Please visit
-http://www.hawksoft.com/hawknl/
+https://web.archive.org/web/20150606035441/http://hawksoft.com/hawknl/
 for information about how to download, build, and install the SDK.
 I am using version 1.68 of HawkNL.
 


### PR DESCRIPTION
Quick fix for broken link to HawkNL. Solves #4.
The proposed solution in issue #3 is probably a better option in the long run though.