### PR TITLE
SDL2 examples port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 Makefile
-OpenDis.make
+*.make
 *.obj
 *.vcxproj*
 *.sln

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,25 @@ install:
   - make config=release
   - cd ../../..
   - mv premake-5.0.0-alpha6/bin/release/premake5 premake5
-  
+  # Download and build both SDL2 from source
+  - wget http://libsdl.org/release/SDL2-2.0.9.tar.gz
+  - tar -xvf SDL2-2.0.9.tar.gz
+  - pushd SDL2-2.0.9/
+  - ./configure --prefix=/usr && make && sudo make install
+  - popd
+  # Run sdl2-config for debugging -- protentially remove this
+  - sdl2-config --cflags --libs
+  # Download and build both SDL2_net from source
+  - wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz
+  - tar -xvf SDL2_net-2.0.1.tar.gz
+  - pushd SDL2_net-2.0.1/
+  - ./configure --prefix=/usr && make && sudo make install
+  - popd
+
+
 # Run premake to generate makefiles.
 before_script:
   - ./premake5 gmake
-  
-script: 
+
+script:
   - make config=release

--- a/examples/Connection.h
+++ b/examples/Connection.h
@@ -1,9 +1,11 @@
 #ifndef _example_dis_connection_h_
 #define _example_dis_connection_h_
 
-#include <nl.h>                          // for member & implementation
 #include <string>                        // for param
 #include <cstddef>                       // for size_t definition
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_net.h>
 
 
 namespace Example
@@ -17,7 +19,7 @@ namespace Example
    class Connection
    {
    public:
-      void Connect(unsigned int port, const std::string& host);
+      void Connect(unsigned int port, const std::string& host, bool listen);
       void Disconnect();
 
       void Send(const char* buf, size_t numbytes);
@@ -26,12 +28,13 @@ namespace Example
       /// @param buf the buffer to be written to with network bytes
       /// @param numbytes the maximum index used for the buffer (buf)
       /// @return the number of bytes read from the connection
-      size_t Receive(char* buf, size_t numbytes);
+      size_t Receive(char* buf);
 
    private:
       void HandleError();
 
-      NLsocket mSocket;
+      UDPsocket mSocket;
+      IPaddress mAddr;
    };
 }
 

--- a/examples/EntityStatePduProcessor.cpp
+++ b/examples/EntityStatePduProcessor.cpp
@@ -1,4 +1,4 @@
-#include <Example/EntityStatePduProcessor.h>
+#include <examples/EntityStatePduProcessor.h>
 
 #include <iostream>
 
@@ -16,4 +16,3 @@ void EntityStatePduProcessor::Process(const DIS::Pdu& packet)
                 << std::endl;
    }
 }
-

--- a/examples/EntityStatePduProcessor.h
+++ b/examples/EntityStatePduProcessor.h
@@ -1,8 +1,8 @@
 #ifndef _example_entity_state_pdu_processor_h_
 #define _example_entity_state_pdu_processor_h_
 
-#include <DIS/EntityStatePdu.h>                  // for typedef
-#include <DIS/IPacketProcessor.h>                // for base class
+#include <dis6/EntityStatePdu.h>                  // for typedef
+#include <utils/IPacketProcessor.h>                // for base class
 
 namespace Example
 {

--- a/examples/Readme.txt
+++ b/examples/Readme.txt
@@ -4,18 +4,21 @@ It shows how to send/receive data to a DIS network.
 The main idea is to use the library to pack and send/receive data.
 The example socket implementation is outside the scope
 of the DIS implementation, but provided so that the
-testing is complete.  This socket implementation depends
-upon the HawkNL library.  Please visit
-https://web.archive.org/web/20150606035441/http://hawksoft.com/hawknl/
-for information about how to download, build, and install the SDK.
-I am using version 1.68 of HawkNL.
+testing is complete.  This socket implementation depends upon the the SDL2_net
+library. Please visit https://www.libsdl.org/ for information about how to
+ download, build, and install the Libraries.
 
-When compiling, the project files reference the following environment variables:
-HAWKNL_INC_DIR
-HAWKNL_LIB_DIR
+SDL2 also provides timing functionality. I.e. calculating delta between frames
+and for sleep delays.
 
-For example, if the package was located at the following:
-C:\hawknl1.68
-Then the environment variables could be defined as such:
-HAWKNL_INC_DIR=C:\hawknl1.68\include
-HAWKNL_LIB_DIR=C:\hawknl1.68\lib
+The current `#include` are written with the prefix "SDL2/" because the
+contributor was unfamiliar with premake5.
+Normally it is recommended to add the output of `sdl2-config --cflags` and
+`sdl2-config --libs` to the build process, however it was unclear if this
+work across different systems.
+
+Build instructions:
+1. cd to the repo root
+2. run `premake5 gmake` (If not done already)
+3. run `make all`
+Files will be located in ./Build/lib/Debug

--- a/examples/Readme.txt
+++ b/examples/Readme.txt
@@ -20,5 +20,9 @@ work across different systems.
 Build instructions:
 1. cd to the repo root
 2. run `premake5 gmake` (If not done already)
-3. run `make all`
+3. run `make`
 Files will be located in ./Build/lib/Debug
+Running instructions: 
+1. open up 2 terminals in the git repo root:
+2. Run `./Build/lib/Debug/ExampleReciever` in one terminal
+3. Run `./Build/lib/Debug/ExampleSender` in the other terminal

--- a/examples/Timer.cpp
+++ b/examples/Timer.cpp
@@ -1,40 +1,37 @@
 
-#include <Example/Timer.h>
+#include <examples/Timer.h>
 #include <iostream>
+#include "Logging.h"
+
+#include <sstream>
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_timer.h>
 
 using namespace Example;
 
 const double MILLI = 0.001;
 const double MICRO = 0.000001;
 
+Timer::Timer() {
+   // Added to allow Timer to be a stand alone class
+   // Supposedly SDL_Init ignores repeated calls
+   // source : https://discourse.libsdl.org/t/behaviour-of-sdl-init-when-called-more-than-once/6156
+   if (SDL_Init(0) != 0) {
+      std::ostringstream strm;
+      strm << "SDL_Init failed due to error: " << SDL_GetError();
+      LOG_ERROR(strm.str());
+   }
+
+}
+
 void Timer::Update()
 {
-   nlTime( &_time_of_day );
+   _ticks = SDL_GetTicks();
 }
 
-NLlong Timer::GetCurrentSeconds() const
-{
-   return _time_of_day.useconds;
-}
-
-NLlong Timer::GetCurrentMSeconds() const
-{
-   return _time_of_day.useconds;
-}
-
-NLlong Timer::GetCurrentUSeconds() const
-{
-   return _time_of_day.useconds;
-}
 
 double Timer::GetSeconds() const
 {
-   //return( _time_of_day.seconds + _time_of_day.mseconds*MILLI + _time_of_day.useconds*MICRO );
-   return( _time_of_day.seconds + _time_of_day.mseconds*MILLI );
-   //return( _time_of_day.seconds + _time_of_day.useconds*MICRO );
-}
-
-NLtime Timer::GetData() const
-{
-   return _time_of_day;
+   return (_ticks * MILLI);
 }

--- a/examples/Timer.h
+++ b/examples/Timer.h
@@ -1,7 +1,8 @@
 #ifndef _example_timer_h_
 #define _example_timer_h_
 
-#include <nl.h>          // for member
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_timer.h>
 
 namespace Example
 {
@@ -9,19 +10,14 @@ namespace Example
    class Timer
    {
    public:
+      Timer();
       void Update();
 
-      NLlong GetCurrentSeconds() const;
-      NLlong GetCurrentMSeconds() const;
-      NLlong GetCurrentUSeconds() const;
-
-      // @return the time of day in seconds
+      // @return the ms ticks since SDL_Init in seconds
       double GetSeconds() const;
 
-      NLtime GetData() const;
-
    private:
-      NLtime _time_of_day;
+      Uint32 _ticks;
    };
 }
 

--- a/examples/Utils.cpp
+++ b/examples/Utils.cpp
@@ -6,18 +6,15 @@
 #include <unistd.h>
 #endif
 
-#include <DIS/Orientation.h>
-#include <DIS/Vector3Float.h>
-#include <DIS/Vector3Double.h>
+#include <dis6/Orientation.h>
+#include <dis6/Vector3Float.h>
+#include <dis6/Vector3Double.h>
+#include <SDL2/SDL_timer.h>
 
 ///\todo make cross platform solution
 void Example::sleep(unsigned int ms)
 {
-#ifdef WIN32
-   Sleep( ms );
-#else
-   usleep( ms*1000 );
-#endif
+    SDL_Delay(ms);
 }
 
 using namespace Example;

--- a/examples/Utils.h
+++ b/examples/Utils.h
@@ -7,9 +7,9 @@
 #define _USE_MATH_DEFINES
 #include <cmath>
 
-#include <DIS/Vector3Double.h>
-#include <DIS/Vector3Float.h>
-#include <DIS/Orientation.h>
+#include <dis6/Vector3Double.h>
+#include <dis6/Vector3Float.h>
+#include <dis6/Orientation.h>
 
 namespace Example
 {

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,17 +1,17 @@
 
 // specific for the example
-#include <Example/Connection.h>
-#include <Example/Utils.h>
-#include <Example/Timer.h>
+#include <examples/Connection.h>
+#include <examples/Utils.h>
+#include <examples/Timer.h>
 
 // the DIS library usage
-#include <DIS/EntityStatePdu.h>
-#include <DIS/DetonationPdu.h>
-#include <DIS/DataStream.h>
-#include <DIS/Vector3Double.h>
-#include <DIS/BurstDescriptor.h>
+#include <dis6/EntityStatePdu.h>
+#include <dis6/DetonationPdu.h>
+#include <utils/DataStream.h>
+#include <dis6/Vector3Double.h>
+#include <dis6/BurstDescriptor.h>
 
-#include <DIS/Conversion.h>
+#include <utils/Conversion.h>
 
 #include <iostream>
 
@@ -197,7 +197,7 @@ void init_effects(DIS::DetonationPdu &detonation, const DIS::EntityID& firing, c
    }
 
    /// entity id data
-   {           
+   {
       DIS::EntityID detonation_entity_id;
       detonation_entity_id.setSite( 0 );
       detonation_entity_id.setApplication( 1 );
@@ -207,12 +207,12 @@ void init_effects(DIS::DetonationPdu &detonation, const DIS::EntityID& firing, c
    }
 
    /// event id data
-   { 
+   {
       //Event ID.
-      //   This field shall contain the same data as in the Event ID Þeld of the Fire PDU that communicated
-      //   the launch of the munition. If the detonation is not preceded by a corresponding Þre event,
-      //   then the Event Number Þeld of the Event IdentiÞer record shall be zero (e.g., land mines detonation).
-      //   This Þeld shall be represented by an Event IdentiÞer record (see 5.2.18).
+      //   This field shall contain the same data as in the Event ID field of the Fire PDU that communicated
+      //   the launch of the munition. If the detonation is not preceded by a corresponding fire event,
+      //   then the Event Number field of the Event Identifier record shall be zero (e.g., land mines detonation).
+      //   This field shall be represented by an Event Identifier record (see 5.2.18).
 
       // 0200 Point Detonation (PD)
       DIS::EventID detonation_event_id;
@@ -293,7 +293,7 @@ void UpdateTank(DIS::EntityStatePdu& tank, Example::TankDynamics& dynamics, doub
 int main(int argc, char* argv[])
 {
    unsigned int port(62040);
-   std::string ip("239.1.2.3");
+   std::string ip("224.0.0.1");
    if( argc > 2 )
    {
       port = Example::ToType<unsigned int>( argv[1] );
@@ -302,11 +302,11 @@ int main(int argc, char* argv[])
 
    /// the basic pieces for sending data
    Example::Connection multicast;
-   multicast.Connect( port , ip );
+   multicast.Connect( port , ip , false);
    DIS::DataStream buffer( DIS::BIG );
 
    DIS::EntityStatePdu enemy;
-   DIS::EntityStatePdu friendly[2];   
+   DIS::EntityStatePdu friendly[2];
    init_entities( friendly[0], friendly[1], enemy );
 
    DIS::DetonationPdu tank_round;
@@ -331,13 +331,13 @@ int main(int argc, char* argv[])
 
    // define the content to be sent of the network
    double sim_time = 0;
-   double dt = 0;  
+   double dt = 0;
    unsigned int frame_stamp=0;
 
    Example::TimedAlert isDetonationReady(10.0);   // alert us at 10.0 second intervals
    Example::TimedAlert isTimeToPrintStatistics(5.0);   // alert us at 10.0 second intervals
 
-   double last_time = timer.GetSeconds();  
+   double last_time = timer.GetSeconds();
 
    // the simulation loop
    ///\todo find an exit condition so we don't need to explicitly kill the app

--- a/examples/main_receive.cpp
+++ b/examples/main_receive.cpp
@@ -41,6 +41,10 @@ int main(int argc, char* argv[])
 
       // engage the higher level support
       incoming.Process( buffer , bytes_read , endian );
+
+      // Add a short sleep delay to avoid locking up machine
+      // (SDL UDP Reads are non-blocking)
+      Example::sleep(10);
    }
 
    incoming.RemoveProcessor( es_pdu_type , &processor );

--- a/examples/main_receive.cpp
+++ b/examples/main_receive.cpp
@@ -1,18 +1,19 @@
 
-#include <Example/Connection.h>                  // for reading packets from the socket
-#include <Example/EntityStatePduProcessor.h>     // for usage
-#include <Example/Utils.h>
+#include <examples/Connection.h>                  // for reading packets from the socket
+#include <examples/EntityStatePduProcessor.h>     // for usage
+#include <examples/Utils.h>
 
-#include <DIS/IncomingMessage.h>                 // for library usage
-#include <DIS/EntityStatePdu.h>                  // for library usage
+#include <utils/IncomingMessage.h>                 // for library usage
+#include <dis6/EntityStatePdu.h>                  // for library usage
 
 #include <cstring>                       // for strlen
 #include <cstddef>                       // for size_t definition
 
+#include <iostream>
 int main(int argc, char* argv[])
 {
    unsigned int port(62040);
-   std::string ip("239.1.2.3");
+   std::string ip("224.0.0.1");
    if( argc > 2 )
    {
       port = Example::ToType<unsigned int>( argv[1] );
@@ -20,7 +21,7 @@ int main(int argc, char* argv[])
    }
 
    Example::Connection multicast;
-   multicast.Connect( port , ip );
+   multicast.Connect( port , ip , true);
    DIS::Endian endian = DIS::BIG;
 
    char buffer[Example::MTU_SIZE+1];
@@ -36,7 +37,7 @@ int main(int argc, char* argv[])
       ///\todo find a way to use the stream rather than a raw char buffer,
       /// so that copying the buffer into the DataStream within the IncomingMessage
       /// will not be necessary.
-      size_t bytes_read = multicast.Receive( buffer , Example::MTU_SIZE );
+      size_t bytes_read = multicast.Receive( buffer );
 
       // engage the higher level support
       incoming.Process( buffer , bytes_read , endian );
@@ -46,4 +47,3 @@ int main(int argc, char* argv[])
    multicast.Disconnect();
    return 0;
 }
-

--- a/premake5.lua
+++ b/premake5.lua
@@ -4,14 +4,14 @@
 --
 
 workspace "open-dis-cpp"
-  configurations { 
+  configurations {
     "Debug",
     "Release"
   }
   targetdir "Build/lib/%{cfg.buildcfg}"
   configuration "Debug*"
     defines { "DEBUG" }
- 
+
   configuration "Release*"
     defines { "NDEBUG" }
     optimize "On"
@@ -28,10 +28,10 @@ workspace "open-dis-cpp"
 project "OpenDIS"
   language "C++"
   kind "SharedLib"
-  includedirs { 
+  includedirs {
     "src"
   }
-  files { 
+  files {
     "src/dis6/*.h",
     "src/dis6/*.cpp",
     "src/utils/*.h",
@@ -39,22 +39,37 @@ project "OpenDIS"
   }
 
 -- Uncomment this if you have the HawkNL library and want to build the example.
---[[
+
 project "ExampleSender"
   language "C++"
   kind "ConsoleApp"
   includedirs {
-    "cpp",
-    "CppUtils",
+    "src",
     "."
   }
   files {
-    "Example/main.cpp",
-    "Example/Connection.*",
-    "Example/Utils.*",
-    "Example/Timer.*"
+    "examples/main.cpp",
+    "examples/Connection.*",
+    "examples/Utils.*",
+    "examples/Timer.*"
   }
-  links { "OpenDIS", "HawkNL" }
---]]
+  links { "OpenDIS", "SDL2", "SDL2_net" }
+
+project "ExampleReciever"
+  language "C++"
+  kind "ConsoleApp"
+  includedirs {
+    "src",
+    "."
+  }
+  files {
+    "examples/main_receive.cpp",
+    "examples/Connection.*",
+    "examples/Utils.*",
+    "examples/Timer.*",
+	"examples/EntityStatePduProcessor.*"
+  }
+  links { "OpenDIS", "SDL2", "SDL2_net" }
+
 
 -- TODO: add project sections for the unit tests and the examples.


### PR DESCRIPTION
This pull request replaces HawkNL with SDL2.
Addresses issue #3 

Note: 
- Had to use 224.0.0.1 (LAN) multicast address to get it to work, although I'm just using my home router with no special set up (I'm not that familiar with multicast)
- It is usual recommended to use the output of `sdl2-config --cflags` & `sdl2-config --libs` during compilation, however I was unsure if that would work in the premake5 build script, especially cross platform. This means the include statements are written as `#include <SDL2/SDL_XXX.h` rather than `#include <SDL_XXX.h>`, which is all that is required when using `sdl2-config -cflags` output that includes "-I/path/to/SDL2/"  amendment