### PR TITLE
Fix Compiler Warnings + Minor Corrections + OpenDIS7 build target

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -38,6 +38,19 @@ project "OpenDIS"
     "src/utils/*.cpp"
   }
 
+project "OpenDIS7"
+  language "C++"
+  kind "SharedLib"
+  includedirs {
+    "src"
+  }
+  files {
+    "src/dis7/*.h",
+    "src/dis7/*.cpp",
+    "src/utils/*.h",
+    "src/utils/*.cpp"
+  }
+
 project "ExampleSender"
   language "C++"
   kind "ConsoleApp"

--- a/src/dis6/AcousticEmitterSystemData.cpp
+++ b/src/dis6/AcousticEmitterSystemData.cpp
@@ -149,7 +149,7 @@ int AcousticEmitterSystemData::getMarshalledSize() const
    marshalSize = marshalSize + _acousticEmitterSystem.getMarshalledSize();  // _acousticEmitterSystem
    marshalSize = marshalSize + _emitterLocation.getMarshalledSize();  // _emitterLocation
 
-   for(int idx=0; idx < _beamRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _beamRecords.size(); idx++)
    {
         AcousticBeamData listElement = _beamRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/AcousticEmitterSystemData.cpp
+++ b/src/dis6/AcousticEmitterSystemData.cpp
@@ -149,7 +149,7 @@ int AcousticEmitterSystemData::getMarshalledSize() const
    marshalSize = marshalSize + _acousticEmitterSystem.getMarshalledSize();  // _acousticEmitterSystem
    marshalSize = marshalSize + _emitterLocation.getMarshalledSize();  // _emitterLocation
 
-   for(unsigned long idx=0; idx < _beamRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _beamRecords.size(); idx++)
    {
         AcousticBeamData listElement = _beamRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionRequestPdu.cpp
+++ b/src/dis6/ActionRequestPdu.cpp
@@ -161,14 +161,14 @@ int ActionRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionRequestPdu.cpp
+++ b/src/dis6/ActionRequestPdu.cpp
@@ -161,14 +161,14 @@ int ActionRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionRequestReliablePdu.cpp
+++ b/src/dis6/ActionRequestReliablePdu.cpp
@@ -206,14 +206,14 @@ int ActionRequestReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionRequestReliablePdu.cpp
+++ b/src/dis6/ActionRequestReliablePdu.cpp
@@ -206,14 +206,14 @@ int ActionRequestReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionResponsePdu.cpp
+++ b/src/dis6/ActionResponsePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponsePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionResponsePdu.cpp
+++ b/src/dis6/ActionResponsePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponsePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionResponseReliablePdu.cpp
+++ b/src/dis6/ActionResponseReliablePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponseReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ActionResponseReliablePdu.cpp
+++ b/src/dis6/ActionResponseReliablePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponseReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/AggregateMarking.cpp
+++ b/src/dis6/AggregateMarking.cpp
@@ -75,7 +75,7 @@ bool AggregateMarking::operator ==(const AggregateMarking& rhs) const
 
      if( ! (_characterSet == rhs._characterSet) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 31; idx++)
+     for(unsigned char idx = 0; idx < 31; idx++)
      {
           if(!(_characters[idx] == rhs._characters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/AggregateStatePdu.cpp
+++ b/src/dis6/AggregateStatePdu.cpp
@@ -467,14 +467,14 @@ int AggregateStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfSilentAggregateTypes
    marshalSize = marshalSize + 2;  // _numberOfSilentEntityTypes
 
-   for(unsigned long idx=0; idx < _aggregateIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _aggregateIDList.size(); idx++)
    {
         AggregateID listElement = _aggregateIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _entityIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _entityIDList.size(); idx++)
    {
         EntityID listElement = _entityIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -482,14 +482,14 @@ int AggregateStatePdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 1;  // _pad2
 
-   for(unsigned long idx=0; idx < _silentAggregateSystemList.size(); idx++)
+   for(unsigned long long idx=0; idx < _silentAggregateSystemList.size(); idx++)
    {
         EntityType listElement = _silentAggregateSystemList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _silentEntitySystemList.size(); idx++)
+   for(unsigned long long idx=0; idx < _silentEntitySystemList.size(); idx++)
    {
         EntityType listElement = _silentEntitySystemList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -497,7 +497,7 @@ int AggregateStatePdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _variableDatumList.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumList.size(); idx++)
    {
         VariableDatum listElement = _variableDatumList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/AggregateStatePdu.cpp
+++ b/src/dis6/AggregateStatePdu.cpp
@@ -467,14 +467,14 @@ int AggregateStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfSilentAggregateTypes
    marshalSize = marshalSize + 2;  // _numberOfSilentEntityTypes
 
-   for(int idx=0; idx < _aggregateIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _aggregateIDList.size(); idx++)
    {
         AggregateID listElement = _aggregateIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _entityIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _entityIDList.size(); idx++)
    {
         EntityID listElement = _entityIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -482,14 +482,14 @@ int AggregateStatePdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 1;  // _pad2
 
-   for(int idx=0; idx < _silentAggregateSystemList.size(); idx++)
+   for(unsigned long idx=0; idx < _silentAggregateSystemList.size(); idx++)
    {
         EntityType listElement = _silentAggregateSystemList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _silentEntitySystemList.size(); idx++)
+   for(unsigned long idx=0; idx < _silentEntitySystemList.size(); idx++)
    {
         EntityType listElement = _silentEntitySystemList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -497,7 +497,7 @@ int AggregateStatePdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _variableDatumList.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumList.size(); idx++)
    {
         VariableDatum listElement = _variableDatumList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ArealObjectStatePdu.cpp
+++ b/src/dis6/ArealObjectStatePdu.cpp
@@ -250,7 +250,7 @@ int ArealObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _requesterID.getMarshalledSize();  // _requesterID
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
 
-   for(int idx=0; idx < _objectLocation.size(); idx++)
+   for(unsigned long idx=0; idx < _objectLocation.size(); idx++)
    {
         Vector3Double listElement = _objectLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ArealObjectStatePdu.cpp
+++ b/src/dis6/ArealObjectStatePdu.cpp
@@ -250,7 +250,7 @@ int ArealObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _requesterID.getMarshalledSize();  // _requesterID
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
 
-   for(unsigned long idx=0; idx < _objectLocation.size(); idx++)
+   for(unsigned long long idx=0; idx < _objectLocation.size(); idx++)
    {
         Vector3Double listElement = _objectLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/CommentPdu.cpp
+++ b/src/dis6/CommentPdu.cpp
@@ -131,14 +131,14 @@ int CommentPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/CommentPdu.cpp
+++ b/src/dis6/CommentPdu.cpp
@@ -131,14 +131,14 @@ int CommentPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/CommentReliablePdu.cpp
+++ b/src/dis6/CommentReliablePdu.cpp
@@ -131,14 +131,14 @@ int CommentReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/CommentReliablePdu.cpp
+++ b/src/dis6/CommentReliablePdu.cpp
@@ -131,14 +131,14 @@ int CommentReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataPdu.cpp
+++ b/src/dis6/DataPdu.cpp
@@ -161,14 +161,14 @@ int DataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataPdu.cpp
+++ b/src/dis6/DataPdu.cpp
@@ -161,14 +161,14 @@ int DataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataQueryPdu.cpp
+++ b/src/dis6/DataQueryPdu.cpp
@@ -161,14 +161,14 @@ int DataQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataQueryPdu.cpp
+++ b/src/dis6/DataQueryPdu.cpp
@@ -161,14 +161,14 @@ int DataQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataQueryReliablePdu.cpp
+++ b/src/dis6/DataQueryReliablePdu.cpp
@@ -206,14 +206,14 @@ int DataQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataQueryReliablePdu.cpp
+++ b/src/dis6/DataQueryReliablePdu.cpp
@@ -206,14 +206,14 @@ int DataQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataReliablePdu.cpp
+++ b/src/dis6/DataReliablePdu.cpp
@@ -191,14 +191,14 @@ int DataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DataReliablePdu.cpp
+++ b/src/dis6/DataReliablePdu.cpp
@@ -191,14 +191,14 @@ int DataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DeadReckoningParameter.cpp
+++ b/src/dis6/DeadReckoningParameter.cpp
@@ -111,7 +111,7 @@ bool DeadReckoningParameter::operator ==(const DeadReckoningParameter& rhs) cons
 
      if( ! (_deadReckoningAlgorithm == rhs._deadReckoningAlgorithm) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 15; idx++)
+     for(unsigned char idx = 0; idx < 15; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/DetonationPdu.cpp
+++ b/src/dis6/DetonationPdu.cpp
@@ -235,7 +235,7 @@ int DetonationPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfArticulationParameters
    marshalSize = marshalSize + 2;  // _pad
 
-   for(int idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/DetonationPdu.cpp
+++ b/src/dis6/DetonationPdu.cpp
@@ -235,7 +235,7 @@ int DetonationPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfArticulationParameters
    marshalSize = marshalSize + 2;  // _pad
 
-   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EightByteChunk.cpp
+++ b/src/dis6/EightByteChunk.cpp
@@ -61,7 +61,7 @@ bool EightByteChunk::operator ==(const EightByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 8; idx++)
+     for(unsigned char idx = 0; idx < 8; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/ElectronicEmissionBeamData.cpp
+++ b/src/dis6/ElectronicEmissionBeamData.cpp
@@ -204,7 +204,7 @@ int ElectronicEmissionBeamData::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _pad4
    marshalSize = marshalSize + 4;  // _jammingModeSequence
 
-   for(int idx=0; idx < _trackJamTargets.size(); idx++)
+   for(unsigned long idx=0; idx < _trackJamTargets.size(); idx++)
    {
         TrackJamTarget listElement = _trackJamTargets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ElectronicEmissionBeamData.cpp
+++ b/src/dis6/ElectronicEmissionBeamData.cpp
@@ -204,7 +204,7 @@ int ElectronicEmissionBeamData::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _pad4
    marshalSize = marshalSize + 4;  // _jammingModeSequence
 
-   for(unsigned long idx=0; idx < _trackJamTargets.size(); idx++)
+   for(unsigned long long idx=0; idx < _trackJamTargets.size(); idx++)
    {
         TrackJamTarget listElement = _trackJamTargets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ElectronicEmissionSystemData.cpp
+++ b/src/dis6/ElectronicEmissionSystemData.cpp
@@ -149,7 +149,7 @@ int ElectronicEmissionSystemData::getMarshalledSize() const
    marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
    marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
-   for(int idx=0; idx < _beamDataRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _beamDataRecords.size(); idx++)
    {
         ElectronicEmissionBeamData listElement = _beamDataRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ElectronicEmissionSystemData.cpp
+++ b/src/dis6/ElectronicEmissionSystemData.cpp
@@ -149,7 +149,7 @@ int ElectronicEmissionSystemData::getMarshalledSize() const
    marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
    marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
-   for(unsigned long idx=0; idx < _beamDataRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _beamDataRecords.size(); idx++)
    {
         ElectronicEmissionBeamData listElement = _beamDataRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ElectronicEmissionsPdu.cpp
+++ b/src/dis6/ElectronicEmissionsPdu.cpp
@@ -156,7 +156,7 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSystems
    marshalSize = marshalSize + 2;  // _paddingForEmissionsPdu
 
-   for(int idx=0; idx < _systems.size(); idx++)
+   for(unsigned long idx=0; idx < _systems.size(); idx++)
    {
         ElectronicEmissionSystemData listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ElectronicEmissionsPdu.cpp
+++ b/src/dis6/ElectronicEmissionsPdu.cpp
@@ -156,7 +156,7 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSystems
    marshalSize = marshalSize + 2;  // _paddingForEmissionsPdu
 
-   for(unsigned long idx=0; idx < _systems.size(); idx++)
+   for(unsigned long long idx=0; idx < _systems.size(); idx++)
    {
         ElectronicEmissionSystemData listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EntityStatePdu.cpp
+++ b/src/dis6/EntityStatePdu.cpp
@@ -290,7 +290,7 @@ int EntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _marking.getMarshalledSize();  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EntityStatePdu.cpp
+++ b/src/dis6/EntityStatePdu.cpp
@@ -236,7 +236,7 @@ void EntityStatePdu::unmarshal(DataStream& dataStream)
     dataStream >> _capabilities;
 
      _articulationParameters.clear();
-     for(size_t idx = 0; idx < _numberOfArticulationParameters; idx++)
+     for(char idx = 0; idx < _numberOfArticulationParameters; idx++)
      {
         ArticulationParameter x;
         x.unmarshal(dataStream);
@@ -290,7 +290,7 @@ int EntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _marking.getMarshalledSize();  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(int idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EntityStateUpdatePdu.cpp
+++ b/src/dis6/EntityStateUpdatePdu.cpp
@@ -196,7 +196,7 @@ int EntityStateUpdatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _entityOrientation.getMarshalledSize();  // _entityOrientation
    marshalSize = marshalSize + 4;  // _entityAppearance
 
-   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EntityStateUpdatePdu.cpp
+++ b/src/dis6/EntityStateUpdatePdu.cpp
@@ -196,7 +196,7 @@ int EntityStateUpdatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _entityOrientation.getMarshalledSize();  // _entityOrientation
    marshalSize = marshalSize + 4;  // _entityAppearance
 
-   for(int idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EnvironmentalProcessPdu.cpp
+++ b/src/dis6/EnvironmentalProcessPdu.cpp
@@ -170,7 +170,7 @@ int EnvironmentalProcessPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfEnvironmentRecords
    marshalSize = marshalSize + 2;  // _sequenceNumber
 
-   for(int idx=0; idx < _environmentRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _environmentRecords.size(); idx++)
    {
         Environment listElement = _environmentRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EnvironmentalProcessPdu.cpp
+++ b/src/dis6/EnvironmentalProcessPdu.cpp
@@ -170,7 +170,7 @@ int EnvironmentalProcessPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfEnvironmentRecords
    marshalSize = marshalSize + 2;  // _sequenceNumber
 
-   for(unsigned long idx=0; idx < _environmentRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _environmentRecords.size(); idx++)
    {
         Environment listElement = _environmentRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EventReportPdu.cpp
+++ b/src/dis6/EventReportPdu.cpp
@@ -161,14 +161,14 @@ int EventReportPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EventReportPdu.cpp
+++ b/src/dis6/EventReportPdu.cpp
@@ -161,14 +161,14 @@ int EventReportPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EventReportReliablePdu.cpp
+++ b/src/dis6/EventReportReliablePdu.cpp
@@ -161,14 +161,14 @@ int EventReportReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/EventReportReliablePdu.cpp
+++ b/src/dis6/EventReportReliablePdu.cpp
@@ -161,14 +161,14 @@ int EventReportReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/FastEntityStatePdu.cpp
+++ b/src/dis6/FastEntityStatePdu.cpp
@@ -719,7 +719,7 @@ int FastEntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 12 * 1;  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/FastEntityStatePdu.cpp
+++ b/src/dis6/FastEntityStatePdu.cpp
@@ -103,7 +103,7 @@ void FastEntityStatePdu::setForceId(unsigned char pX)
     _forceId = pX;
 }
 
-char FastEntityStatePdu::getNumberOfArticulationParameters() const
+unsigned char FastEntityStatePdu::getNumberOfArticulationParameters() const
 {
    return _articulationParameters.size();
 }
@@ -601,7 +601,7 @@ void FastEntityStatePdu::unmarshal(DataStream& dataStream)
     dataStream >> _capabilities;
 
      _articulationParameters.clear();
-     for(size_t idx = 0; idx < _numberOfArticulationParameters; idx++)
+     for(unsigned char idx = 0; idx < _numberOfArticulationParameters; idx++)
      {
         ArticulationParameter x;
         x.unmarshal(dataStream);
@@ -646,7 +646,7 @@ bool FastEntityStatePdu::operator ==(const FastEntityStatePdu& rhs) const
      if( ! (_entityAppearance == rhs._entityAppearance) ) ivarsEqual = false;
      if( ! (_deadReckoningAlgorithm == rhs._deadReckoningAlgorithm) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 15; idx++)
+     for(unsigned char idx = 0; idx < 15; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }
@@ -658,7 +658,7 @@ bool FastEntityStatePdu::operator ==(const FastEntityStatePdu& rhs) const
      if( ! (_yAngularVelocity == rhs._yAngularVelocity) ) ivarsEqual = false;
      if( ! (_zAngularVelocity == rhs._zAngularVelocity) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 12; idx++)
+     for(unsigned char idx = 0; idx < 12; idx++)
      {
           if(!(_marking[idx] == rhs._marking[idx]) ) ivarsEqual = false;
      }
@@ -719,7 +719,7 @@ int FastEntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 12 * 1;  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(int idx=0; idx < _articulationParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _articulationParameters.size(); idx++)
    {
         ArticulationParameter listElement = _articulationParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/FastEntityStatePdu.h
+++ b/src/dis6/FastEntityStatePdu.h
@@ -32,7 +32,7 @@ protected:
   unsigned char _forceId; 
 
   /** How many articulation parameters are in the variable length list */
-  char _numberOfArticulationParameters; 
+  unsigned char _numberOfArticulationParameters;
 
   /** Kind of entity */
   unsigned char _entityKind; 
@@ -154,7 +154,7 @@ protected:
     unsigned char getForceId() const; 
     void setForceId(unsigned char pX); 
 
-    char getNumberOfArticulationParameters() const; 
+    unsigned char getNumberOfArticulationParameters() const;
 
     unsigned char getEntityKind() const; 
     void setEntityKind(unsigned char pX); 

--- a/src/dis6/FourByteChunk.cpp
+++ b/src/dis6/FourByteChunk.cpp
@@ -61,7 +61,7 @@ bool FourByteChunk::operator ==(const FourByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 4; idx++)
+     for(unsigned char idx = 0; idx < 4; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/GridAxisRecordRepresentation0.cpp
+++ b/src/dis6/GridAxisRecordRepresentation0.cpp
@@ -84,7 +84,7 @@ int GridAxisRecordRepresentation0::getMarshalledSize() const
    marshalSize = GridAxisRecord::getMarshalledSize();
    marshalSize = marshalSize + 2;  // _numberOfBytes
 
-   for(int idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
    {
         OneByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GridAxisRecordRepresentation0.cpp
+++ b/src/dis6/GridAxisRecordRepresentation0.cpp
@@ -84,7 +84,7 @@ int GridAxisRecordRepresentation0::getMarshalledSize() const
    marshalSize = GridAxisRecord::getMarshalledSize();
    marshalSize = marshalSize + 2;  // _numberOfBytes
 
-   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long long idx=0; idx < _dataValues.size(); idx++)
    {
         OneByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GridAxisRecordRepresentation1.cpp
+++ b/src/dis6/GridAxisRecordRepresentation1.cpp
@@ -114,7 +114,7 @@ int GridAxisRecordRepresentation1::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _fieldOffset
    marshalSize = marshalSize + 2;  // _numberOfValues
 
-   for(int idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
    {
         TwoByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GridAxisRecordRepresentation1.cpp
+++ b/src/dis6/GridAxisRecordRepresentation1.cpp
@@ -114,7 +114,7 @@ int GridAxisRecordRepresentation1::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _fieldOffset
    marshalSize = marshalSize + 2;  // _numberOfValues
 
-   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long long idx=0; idx < _dataValues.size(); idx++)
    {
         TwoByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GridAxisRecordRepresentation2.cpp
+++ b/src/dis6/GridAxisRecordRepresentation2.cpp
@@ -84,7 +84,7 @@ int GridAxisRecordRepresentation2::getMarshalledSize() const
    marshalSize = GridAxisRecord::getMarshalledSize();
    marshalSize = marshalSize + 2;  // _numberOfValues
 
-   for(int idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
    {
         FourByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GridAxisRecordRepresentation2.cpp
+++ b/src/dis6/GridAxisRecordRepresentation2.cpp
@@ -84,7 +84,7 @@ int GridAxisRecordRepresentation2::getMarshalledSize() const
    marshalSize = GridAxisRecord::getMarshalledSize();
    marshalSize = marshalSize + 2;  // _numberOfValues
 
-   for(unsigned long idx=0; idx < _dataValues.size(); idx++)
+   for(unsigned long long idx=0; idx < _dataValues.size(); idx++)
    {
         FourByteChunk listElement = _dataValues[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GriddedDataPdu.cpp
+++ b/src/dis6/GriddedDataPdu.cpp
@@ -295,7 +295,7 @@ int GriddedDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(int idx=0; idx < _gridDataList.size(); idx++)
+   for(unsigned long idx=0; idx < _gridDataList.size(); idx++)
    {
         GridAxisRecord listElement = _gridDataList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GriddedDataPdu.cpp
+++ b/src/dis6/GriddedDataPdu.cpp
@@ -127,12 +127,12 @@ void GriddedDataPdu::setOrientation(const Orientation &pX)
     _orientation = pX;
 }
 
-long GriddedDataPdu::getSampleTime() const
+unsigned long long GriddedDataPdu::getSampleTime() const
 {
     return _sampleTime;
 }
 
-void GriddedDataPdu::setSampleTime(long pX)
+void GriddedDataPdu::setSampleTime(unsigned long long pX)
 {
     _sampleTime = pX;
 }
@@ -295,7 +295,7 @@ int GriddedDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(unsigned long idx=0; idx < _gridDataList.size(); idx++)
+   for(unsigned long long idx=0; idx < _gridDataList.size(); idx++)
    {
         GridAxisRecord listElement = _gridDataList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/GriddedDataPdu.h
+++ b/src/dis6/GriddedDataPdu.h
@@ -50,7 +50,7 @@ protected:
   Orientation _orientation; 
 
   /** valid time of the enviormental data sample, 64 bit unsigned int */
-  long _sampleTime; 
+  unsigned long long _sampleTime;
 
   /** total number of all data values for all pdus for an environmental sample */
   unsigned int _totalValues; 
@@ -104,8 +104,8 @@ protected:
     const Orientation&  getOrientation() const; 
     void setOrientation(const Orientation    &pX);
 
-    long getSampleTime() const; 
-    void setSampleTime(long pX); 
+    unsigned long long getSampleTime() const;
+    void setSampleTime(unsigned long long pX);
 
     unsigned int getTotalValues() const; 
     void setTotalValues(unsigned int pX); 

--- a/src/dis6/IffAtcNavAidsLayer2Pdu.cpp
+++ b/src/dis6/IffAtcNavAidsLayer2Pdu.cpp
@@ -135,7 +135,7 @@ int IffAtcNavAidsLayer2Pdu::getMarshalledSize() const
    marshalSize = marshalSize + _beamData.getMarshalledSize();  // _beamData
    marshalSize = marshalSize + _secondaryOperationalData.getMarshalledSize();  // _secondaryOperationalData
 
-   for(int idx=0; idx < _fundamentalIffParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _fundamentalIffParameters.size(); idx++)
    {
         FundamentalParameterDataIff listElement = _fundamentalIffParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IffAtcNavAidsLayer2Pdu.cpp
+++ b/src/dis6/IffAtcNavAidsLayer2Pdu.cpp
@@ -135,7 +135,7 @@ int IffAtcNavAidsLayer2Pdu::getMarshalledSize() const
    marshalSize = marshalSize + _beamData.getMarshalledSize();  // _beamData
    marshalSize = marshalSize + _secondaryOperationalData.getMarshalledSize();  // _secondaryOperationalData
 
-   for(unsigned long idx=0; idx < _fundamentalIffParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _fundamentalIffParameters.size(); idx++)
    {
         FundamentalParameterDataIff listElement = _fundamentalIffParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IntercomControlPdu.cpp
+++ b/src/dis6/IntercomControlPdu.cpp
@@ -245,7 +245,7 @@ int IntercomControlPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _masterCommunicationsDeviceID
    marshalSize = marshalSize + 4;  // _intercomParametersLength
 
-   for(unsigned long idx=0; idx < _intercomParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _intercomParameters.size(); idx++)
    {
         IntercomCommunicationsParameters listElement = _intercomParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IntercomControlPdu.cpp
+++ b/src/dis6/IntercomControlPdu.cpp
@@ -245,7 +245,7 @@ int IntercomControlPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _masterCommunicationsDeviceID
    marshalSize = marshalSize + 4;  // _intercomParametersLength
 
-   for(int idx=0; idx < _intercomParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _intercomParameters.size(); idx++)
    {
         IntercomCommunicationsParameters listElement = _intercomParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IntercomSignalPdu.cpp
+++ b/src/dis6/IntercomSignalPdu.cpp
@@ -180,7 +180,7 @@ int IntercomSignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(unsigned long idx=0; idx < _data.size(); idx++)
+   for(unsigned long long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IntercomSignalPdu.cpp
+++ b/src/dis6/IntercomSignalPdu.cpp
@@ -180,7 +180,7 @@ int IntercomSignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(int idx=0; idx < _data.size(); idx++)
+   for(unsigned long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IsGroupOfPdu.cpp
+++ b/src/dis6/IsGroupOfPdu.cpp
@@ -165,7 +165,7 @@ int IsGroupOfPdu::getMarshalledSize() const
    marshalSize = marshalSize + 8;  // _latitude
    marshalSize = marshalSize + 8;  // _longitude
 
-   for(unsigned long idx=0; idx < _groupedEntityDescriptions.size(); idx++)
+   for(unsigned long long idx=0; idx < _groupedEntityDescriptions.size(); idx++)
    {
         VariableDatum listElement = _groupedEntityDescriptions[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/IsGroupOfPdu.cpp
+++ b/src/dis6/IsGroupOfPdu.cpp
@@ -165,7 +165,7 @@ int IsGroupOfPdu::getMarshalledSize() const
    marshalSize = marshalSize + 8;  // _latitude
    marshalSize = marshalSize + 8;  // _longitude
 
-   for(int idx=0; idx < _groupedEntityDescriptions.size(); idx++)
+   for(unsigned long idx=0; idx < _groupedEntityDescriptions.size(); idx++)
    {
         VariableDatum listElement = _groupedEntityDescriptions[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/LinearObjectStatePdu.cpp
+++ b/src/dis6/LinearObjectStatePdu.cpp
@@ -215,7 +215,7 @@ int LinearObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + _objectType.getMarshalledSize();  // _objectType
 
-   for(int idx=0; idx < _linearSegmentParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _linearSegmentParameters.size(); idx++)
    {
         LinearSegmentParameter listElement = _linearSegmentParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/LinearObjectStatePdu.cpp
+++ b/src/dis6/LinearObjectStatePdu.cpp
@@ -215,7 +215,7 @@ int LinearObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + _objectType.getMarshalledSize();  // _objectType
 
-   for(unsigned long idx=0; idx < _linearSegmentParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _linearSegmentParameters.size(); idx++)
    {
         LinearSegmentParameter listElement = _linearSegmentParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/Marking.cpp
+++ b/src/dis6/Marking.cpp
@@ -84,7 +84,7 @@ bool Marking::operator ==(const Marking& rhs) const
 
      if( ! (_characterSet == rhs._characterSet) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 11; idx++)
+     for(unsigned char idx = 0; idx < 11; idx++)
      {
           if(!(_characters[idx] == rhs._characters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/MinefieldDataPdu.cpp
+++ b/src/dis6/MinefieldDataPdu.cpp
@@ -295,7 +295,7 @@ int MinefieldDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _dataFilter
    marshalSize = marshalSize + _mineType.getMarshalledSize();  // _mineType
 
-   for(unsigned long idx=0; idx < _sensorTypes.size(); idx++)
+   for(unsigned long long idx=0; idx < _sensorTypes.size(); idx++)
    {
         TwoByteChunk listElement = _sensorTypes[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -303,7 +303,7 @@ int MinefieldDataPdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 1;  // _pad3
 
-   for(unsigned long idx=0; idx < _mineLocation.size(); idx++)
+   for(unsigned long long idx=0; idx < _mineLocation.size(); idx++)
    {
         Vector3Float listElement = _mineLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldDataPdu.cpp
+++ b/src/dis6/MinefieldDataPdu.cpp
@@ -295,7 +295,7 @@ int MinefieldDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _dataFilter
    marshalSize = marshalSize + _mineType.getMarshalledSize();  // _mineType
 
-   for(int idx=0; idx < _sensorTypes.size(); idx++)
+   for(unsigned long idx=0; idx < _sensorTypes.size(); idx++)
    {
         TwoByteChunk listElement = _sensorTypes[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
@@ -303,7 +303,7 @@ int MinefieldDataPdu::getMarshalledSize() const
 
    marshalSize = marshalSize + 1;  // _pad3
 
-   for(int idx=0; idx < _mineLocation.size(); idx++)
+   for(unsigned long idx=0; idx < _mineLocation.size(); idx++)
    {
         Vector3Float listElement = _mineLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldQueryPdu.cpp
+++ b/src/dis6/MinefieldQueryPdu.cpp
@@ -236,14 +236,14 @@ int MinefieldQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _dataFilter
    marshalSize = marshalSize + _requestedMineType.getMarshalledSize();  // _requestedMineType
 
-   for(unsigned long idx=0; idx < _requestedPerimeterPoints.size(); idx++)
+   for(unsigned long long idx=0; idx < _requestedPerimeterPoints.size(); idx++)
    {
         Point listElement = _requestedPerimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _sensorTypes.size(); idx++)
+   for(unsigned long long idx=0; idx < _sensorTypes.size(); idx++)
    {
         TwoByteChunk listElement = _sensorTypes[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldQueryPdu.cpp
+++ b/src/dis6/MinefieldQueryPdu.cpp
@@ -236,14 +236,14 @@ int MinefieldQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _dataFilter
    marshalSize = marshalSize + _requestedMineType.getMarshalledSize();  // _requestedMineType
 
-   for(int idx=0; idx < _requestedPerimeterPoints.size(); idx++)
+   for(unsigned long idx=0; idx < _requestedPerimeterPoints.size(); idx++)
    {
         Point listElement = _requestedPerimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _sensorTypes.size(); idx++)
+   for(unsigned long idx=0; idx < _sensorTypes.size(); idx++)
    {
         TwoByteChunk listElement = _sensorTypes[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldResponseNackPdu.cpp
+++ b/src/dis6/MinefieldResponseNackPdu.cpp
@@ -140,7 +140,7 @@ int MinefieldResponseNackPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _requestID
    marshalSize = marshalSize + 1;  // _numberOfMissingPdus
 
-   for(int idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
+   for(unsigned long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
    {
         EightByteChunk listElement = _missingPduSequenceNumbers[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldResponseNackPdu.cpp
+++ b/src/dis6/MinefieldResponseNackPdu.cpp
@@ -140,7 +140,7 @@ int MinefieldResponseNackPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _requestID
    marshalSize = marshalSize + 1;  // _numberOfMissingPdus
 
-   for(unsigned long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
+   for(unsigned long long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
    {
         EightByteChunk listElement = _missingPduSequenceNumbers[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldStatePdu.cpp
+++ b/src/dis6/MinefieldStatePdu.cpp
@@ -271,14 +271,14 @@ int MinefieldStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _appearance
    marshalSize = marshalSize + 2;  // _protocolMode
 
-   for(int idx=0; idx < _perimeterPoints.size(); idx++)
+   for(unsigned long idx=0; idx < _perimeterPoints.size(); idx++)
    {
         Point listElement = _perimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _mineType.size(); idx++)
+   for(unsigned long idx=0; idx < _mineType.size(); idx++)
    {
         EntityType listElement = _mineType[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/MinefieldStatePdu.cpp
+++ b/src/dis6/MinefieldStatePdu.cpp
@@ -271,14 +271,14 @@ int MinefieldStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _appearance
    marshalSize = marshalSize + 2;  // _protocolMode
 
-   for(unsigned long idx=0; idx < _perimeterPoints.size(); idx++)
+   for(unsigned long long idx=0; idx < _perimeterPoints.size(); idx++)
    {
         Point listElement = _perimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _mineType.size(); idx++)
+   for(unsigned long long idx=0; idx < _mineType.size(); idx++)
    {
         EntityType listElement = _mineType[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/OneByteChunk.cpp
+++ b/src/dis6/OneByteChunk.cpp
@@ -61,7 +61,7 @@ bool OneByteChunk::operator ==(const OneByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 1; idx++)
+     for(unsigned char idx = 0; idx < 1; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/PduContainer.cpp
+++ b/src/dis6/PduContainer.cpp
@@ -79,7 +79,7 @@ int PduContainer::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfPdus
 
-   for(unsigned long idx=0; idx < _pdus.size(); idx++)
+   for(unsigned long long idx=0; idx < _pdus.size(); idx++)
    {
         Pdu listElement = _pdus[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/PduContainer.cpp
+++ b/src/dis6/PduContainer.cpp
@@ -50,7 +50,7 @@ void PduContainer::unmarshal(DataStream& dataStream)
     dataStream >> _numberOfPdus;
 
      _pdus.clear();
-     for(size_t idx = 0; idx < _numberOfPdus; idx++)
+     for(int idx = 0; idx < _numberOfPdus; idx++)
      {
         Pdu x;
         x.unmarshal(dataStream);
@@ -79,7 +79,7 @@ int PduContainer::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfPdus
 
-   for(int idx=0; idx < _pdus.size(); idx++)
+   for(unsigned long idx=0; idx < _pdus.size(); idx++)
    {
         Pdu listElement = _pdus[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/RecordQueryReliablePdu.cpp
+++ b/src/dis6/RecordQueryReliablePdu.cpp
@@ -175,7 +175,7 @@ int RecordQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _time
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(int idx=0; idx < _recordIDs.size(); idx++)
+   for(unsigned long idx=0; idx < _recordIDs.size(); idx++)
    {
         FourByteChunk listElement = _recordIDs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/RecordQueryReliablePdu.cpp
+++ b/src/dis6/RecordQueryReliablePdu.cpp
@@ -175,7 +175,7 @@ int RecordQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _time
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(unsigned long idx=0; idx < _recordIDs.size(); idx++)
+   for(unsigned long long idx=0; idx < _recordIDs.size(); idx++)
    {
         FourByteChunk listElement = _recordIDs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ResupplyOfferPdu.cpp
+++ b/src/dis6/ResupplyOfferPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyOfferPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ResupplyOfferPdu.cpp
+++ b/src/dis6/ResupplyOfferPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyOfferPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ResupplyReceivedPdu.cpp
+++ b/src/dis6/ResupplyReceivedPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyReceivedPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ResupplyReceivedPdu.cpp
+++ b/src/dis6/ResupplyReceivedPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyReceivedPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SeesPdu.cpp
+++ b/src/dis6/SeesPdu.cpp
@@ -196,14 +196,14 @@ int SeesPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfPropulsionSystems
    marshalSize = marshalSize + 2;  // _numberOfVectoringNozzleSystems
 
-   for(int idx=0; idx < _propulsionSystemData.size(); idx++)
+   for(unsigned long idx=0; idx < _propulsionSystemData.size(); idx++)
    {
         PropulsionSystemData listElement = _propulsionSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _vectoringSystemData.size(); idx++)
+   for(unsigned long idx=0; idx < _vectoringSystemData.size(); idx++)
    {
         VectoringNozzleSystemData listElement = _vectoringSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SeesPdu.cpp
+++ b/src/dis6/SeesPdu.cpp
@@ -196,14 +196,14 @@ int SeesPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfPropulsionSystems
    marshalSize = marshalSize + 2;  // _numberOfVectoringNozzleSystems
 
-   for(unsigned long idx=0; idx < _propulsionSystemData.size(); idx++)
+   for(unsigned long long idx=0; idx < _propulsionSystemData.size(); idx++)
    {
         PropulsionSystemData listElement = _propulsionSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _vectoringSystemData.size(); idx++)
+   for(unsigned long long idx=0; idx < _vectoringSystemData.size(); idx++)
    {
         VectoringNozzleSystemData listElement = _vectoringSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ServiceRequestPdu.cpp
+++ b/src/dis6/ServiceRequestPdu.cpp
@@ -155,7 +155,7 @@ int ServiceRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSupplyTypes
    marshalSize = marshalSize + 2;  // _serviceRequestPadding
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/ServiceRequestPdu.cpp
+++ b/src/dis6/ServiceRequestPdu.cpp
@@ -155,7 +155,7 @@ int ServiceRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSupplyTypes
    marshalSize = marshalSize + 2;  // _serviceRequestPadding
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetDataPdu.cpp
+++ b/src/dis6/SetDataPdu.cpp
@@ -161,14 +161,14 @@ int SetDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetDataPdu.cpp
+++ b/src/dis6/SetDataPdu.cpp
@@ -161,14 +161,14 @@ int SetDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetDataReliablePdu.cpp
+++ b/src/dis6/SetDataReliablePdu.cpp
@@ -191,14 +191,14 @@ int SetDataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetDataReliablePdu.cpp
+++ b/src/dis6/SetDataReliablePdu.cpp
@@ -191,14 +191,14 @@ int SetDataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetRecordReliablePdu.cpp
+++ b/src/dis6/SetRecordReliablePdu.cpp
@@ -145,7 +145,7 @@ int SetRecordReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _pad2
    marshalSize = marshalSize + 4;  // _numberOfRecordSets
 
-   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSet listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SetRecordReliablePdu.cpp
+++ b/src/dis6/SetRecordReliablePdu.cpp
@@ -145,7 +145,7 @@ int SetRecordReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _pad2
    marshalSize = marshalSize + 4;  // _numberOfRecordSets
 
-   for(int idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSet listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SignalPdu.cpp
+++ b/src/dis6/SignalPdu.cpp
@@ -105,7 +105,7 @@ void SignalPdu::unmarshal(DataStream& dataStream)
     dataStream >> _samples;
 
      _data.clear();
-     for(size_t idx = 0; idx < _dataLength; idx++)
+     for(short idx = 0; idx < _dataLength; idx++)
      {
         OneByteChunk x;
         x.unmarshal(dataStream);
@@ -145,7 +145,7 @@ int SignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(int idx=0; idx < _data.size(); idx++)
+   for(unsigned long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SignalPdu.cpp
+++ b/src/dis6/SignalPdu.cpp
@@ -105,7 +105,7 @@ void SignalPdu::unmarshal(DataStream& dataStream)
     dataStream >> _samples;
 
      _data.clear();
-     for(short idx = 0; idx < _dataLength; idx++)
+     for(unsigned short idx = 0; idx < _dataLength; idx++)
      {
         OneByteChunk x;
         x.unmarshal(dataStream);
@@ -145,7 +145,7 @@ int SignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(unsigned long idx=0; idx < _data.size(); idx++)
+   for(unsigned long long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/SixByteChunk.cpp
+++ b/src/dis6/SixByteChunk.cpp
@@ -61,7 +61,7 @@ bool SixByteChunk::operator ==(const SixByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 6; idx++)
+     for(unsigned char idx = 0; idx < 6; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/TransferControlRequestPdu.cpp
+++ b/src/dis6/TransferControlRequestPdu.cpp
@@ -190,7 +190,7 @@ int TransferControlRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + _transferEntityID.getMarshalledSize();  // _transferEntityID
    marshalSize = marshalSize + 1;  // _numberOfRecordSets
 
-   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSet listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/TransferControlRequestPdu.cpp
+++ b/src/dis6/TransferControlRequestPdu.cpp
@@ -190,7 +190,7 @@ int TransferControlRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + _transferEntityID.getMarshalledSize();  // _transferEntityID
    marshalSize = marshalSize + 1;  // _numberOfRecordSets
 
-   for(int idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSet listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/TransmitterPdu.cpp
+++ b/src/dis6/TransmitterPdu.cpp
@@ -376,14 +376,14 @@ int TransmitterPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding2
    marshalSize = marshalSize + 1;  // _padding3
 
-   for(int idx=0; idx < _modulationParametersList.size(); idx++)
+   for(unsigned long idx=0; idx < _modulationParametersList.size(); idx++)
    {
         Vector3Float listElement = _modulationParametersList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _antennaPatternList.size(); idx++)
+   for(unsigned long idx=0; idx < _antennaPatternList.size(); idx++)
    {
         Vector3Float listElement = _antennaPatternList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/TransmitterPdu.cpp
+++ b/src/dis6/TransmitterPdu.cpp
@@ -121,12 +121,12 @@ unsigned short TransmitterPdu::getAntennaPatternCount() const
    return _antennaPatternList.size();
 }
 
-long TransmitterPdu::getFrequency() const
+unsigned long long TransmitterPdu::getFrequency() const
 {
     return _frequency;
 }
 
-void TransmitterPdu::setFrequency(long pX)
+void TransmitterPdu::setFrequency(unsigned long long pX)
 {
     _frequency = pX;
 }
@@ -376,14 +376,14 @@ int TransmitterPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding2
    marshalSize = marshalSize + 1;  // _padding3
 
-   for(unsigned long idx=0; idx < _modulationParametersList.size(); idx++)
+   for(unsigned long long idx=0; idx < _modulationParametersList.size(); idx++)
    {
         Vector3Float listElement = _modulationParametersList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _antennaPatternList.size(); idx++)
+   for(unsigned long long idx=0; idx < _antennaPatternList.size(); idx++)
    {
         Vector3Float listElement = _antennaPatternList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/TransmitterPdu.h
+++ b/src/dis6/TransmitterPdu.h
@@ -49,7 +49,7 @@ protected:
   unsigned short _antennaPatternCount; 
 
   /** frequency */
-  long _frequency; 
+  unsigned long long _frequency;
 
   /** transmit frequency Bandwidth */
   float _transmitFrequencyBandwidth; 
@@ -115,8 +115,8 @@ protected:
 
     unsigned short getAntennaPatternCount() const; 
 
-    long getFrequency() const; 
-    void setFrequency(long pX); 
+    unsigned long long getFrequency() const;
+    void setFrequency(unsigned long long pX);
 
     float getTransmitFrequencyBandwidth() const; 
     void setTransmitFrequencyBandwidth(float pX); 

--- a/src/dis6/TwoByteChunk.cpp
+++ b/src/dis6/TwoByteChunk.cpp
@@ -61,7 +61,7 @@ bool TwoByteChunk::operator ==(const TwoByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 2; idx++)
+     for(short idx = 0; idx < 2; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/TwoByteChunk.cpp
+++ b/src/dis6/TwoByteChunk.cpp
@@ -61,7 +61,7 @@ bool TwoByteChunk::operator ==(const TwoByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(short idx = 0; idx < 2; idx++)
+     for(unsigned char idx = 0; idx < 2; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis6/UaPdu.cpp
+++ b/src/dis6/UaPdu.cpp
@@ -277,21 +277,21 @@ int UaPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfAPAs
    marshalSize = marshalSize + 1;  // _numberOfUAEmitterSystems
 
-   for(unsigned long idx=0; idx < _shaftRPMs.size(); idx++)
+   for(unsigned long long idx=0; idx < _shaftRPMs.size(); idx++)
    {
         ShaftRPMs listElement = _shaftRPMs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _apaData.size(); idx++)
+   for(unsigned long long idx=0; idx < _apaData.size(); idx++)
    {
         ApaData listElement = _apaData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _emitterSystems.size(); idx++)
+   for(unsigned long long idx=0; idx < _emitterSystems.size(); idx++)
    {
         AcousticEmitterSystemData listElement = _emitterSystems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/UaPdu.cpp
+++ b/src/dis6/UaPdu.cpp
@@ -277,21 +277,21 @@ int UaPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfAPAs
    marshalSize = marshalSize + 1;  // _numberOfUAEmitterSystems
 
-   for(int idx=0; idx < _shaftRPMs.size(); idx++)
+   for(unsigned long idx=0; idx < _shaftRPMs.size(); idx++)
    {
         ShaftRPMs listElement = _shaftRPMs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _apaData.size(); idx++)
+   for(unsigned long idx=0; idx < _apaData.size(); idx++)
    {
         ApaData listElement = _apaData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _emitterSystems.size(); idx++)
+   for(unsigned long idx=0; idx < _emitterSystems.size(); idx++)
    {
         AcousticEmitterSystemData listElement = _emitterSystems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis6/VariableDatum.cpp
+++ b/src/dis6/VariableDatum.cpp
@@ -18,22 +18,22 @@ VariableDatum::~VariableDatum()
 	//delete [] _variableDatums;
 }
 
-unsigned long VariableDatum::getVariableDatumID() const
+unsigned int VariableDatum::getVariableDatumID() const
 {
     return _variableDatumID;
 }
 
-void VariableDatum::setVariableDatumID(unsigned long pX)
+void VariableDatum::setVariableDatumID(unsigned int pX)
 {
     _variableDatumID = pX;
 }
 
-unsigned long VariableDatum::getVariableDatumLength() const
+unsigned int VariableDatum::getVariableDatumLength() const
 {
     return _variableDatumLength;
 }
 
-void VariableDatum::setVariableDatumLength(unsigned long pX)
+void VariableDatum::setVariableDatumLength(unsigned int pX)
 {
     _variableDatumLength = pX;
 }
@@ -48,13 +48,13 @@ const char* VariableDatum::getVariableDatums() const
     return _variableDatums.data();
 }
 
-void VariableDatum::setVariableDatums(const char* x, const unsigned long length)
+void VariableDatum::setVariableDatums(const char* x, const unsigned int length)
 {
     // convert and store length as bits
     _variableDatumLength = length * 8;
 
     // Figure out _arrayLength (bytes with padding (8 byte chunks))
-    unsigned long chunks = length / 8;
+    unsigned int chunks = length / 8;
     int remainder = length % 8;
     if(remainder > 0)
 		chunks++;
@@ -64,7 +64,7 @@ void VariableDatum::setVariableDatums(const char* x, const unsigned long length)
     if(_variableDatums.size() < length)
         _variableDatums.resize(length);
 
-    for(unsigned long i = 0; i < length; i++)
+    for(unsigned int i = 0; i < length; i++)
     {
         _variableDatums[i] = x[i];
     }
@@ -79,7 +79,7 @@ void VariableDatum::marshal(DataStream& dataStream) const
     dataStream << _variableDatumID;
     dataStream << _variableDatumLength;
 
-    for(unsigned long idx = 0; idx < _arrayLength; idx++)
+    for(unsigned int idx = 0; idx < _arrayLength; idx++)
     {
         dataStream << _variableDatums[idx];
     }
@@ -103,7 +103,7 @@ void VariableDatum::unmarshal(DataStream& dataStream)
     if(_variableDatums.size() < _arrayLength)
         _variableDatums.resize(_arrayLength);
 
-     for(unsigned long idx = 0; idx < _arrayLength; idx++)
+     for(unsigned int idx = 0; idx < _arrayLength; idx++)
      {
         dataStream >> _variableDatums[idx];
 		//std::cout << (int)_variableDatums[idx] << " ";
@@ -134,9 +134,9 @@ bool VariableDatum::operator ==(const VariableDatum& rhs) const
     return ivarsEqual;
 }
 
-unsigned long VariableDatum::getMarshalledSize() const
+unsigned int VariableDatum::getMarshalledSize() const
 {
-   unsigned long marshalSize = 0;
+   unsigned int marshalSize = 0;
 
    marshalSize = marshalSize + 4;  // _variableDatumID
    marshalSize = marshalSize + 4;  // _variableDatumLength

--- a/src/dis6/VariableDatum.cpp
+++ b/src/dis6/VariableDatum.cpp
@@ -109,7 +109,7 @@ void VariableDatum::unmarshal(DataStream& dataStream)
 		//std::cout << (int)_variableDatums[idx] << " ";
      }
 	 //std::cout << std::endl;
-     for(unsigned long idx = _arrayLength; idx < _variableDatums.size(); idx++)
+     for(unsigned long long idx = _arrayLength; idx < _variableDatums.size(); idx++)
 	 {
 		 _variableDatums[idx] = 0;
 	 }

--- a/src/dis6/VariableDatum.cpp
+++ b/src/dis6/VariableDatum.cpp
@@ -53,7 +53,7 @@ void VariableDatum::setVariableDatums(const char* x, const unsigned int length)
     // convert and store length as bits
     _variableDatumLength = length * 8;
 
-    // Figure out _arrayLength (bytes with padding (8 byte chunks))
+    // Figure out _arrayLength (including padding to force whole 8 byte chunks)
     unsigned int chunks = length / 8;
     int remainder = length % 8;
     if(remainder > 0)

--- a/src/dis6/VariableDatum.cpp
+++ b/src/dis6/VariableDatum.cpp
@@ -18,22 +18,22 @@ VariableDatum::~VariableDatum()
 	//delete [] _variableDatums;
 }
 
-unsigned int VariableDatum::getVariableDatumID() const
+unsigned long VariableDatum::getVariableDatumID() const
 {
     return _variableDatumID;
 }
 
-void VariableDatum::setVariableDatumID(unsigned int pX)
+void VariableDatum::setVariableDatumID(unsigned long pX)
 {
     _variableDatumID = pX;
 }
 
-unsigned int VariableDatum::getVariableDatumLength() const
+unsigned long VariableDatum::getVariableDatumLength() const
 {
     return _variableDatumLength;
 }
 
-void VariableDatum::setVariableDatumLength(unsigned int pX)
+void VariableDatum::setVariableDatumLength(unsigned long pX)
 {
     _variableDatumLength = pX;
 }
@@ -48,35 +48,27 @@ const char* VariableDatum::getVariableDatums() const
     return _variableDatums.data();
 }
 
-void VariableDatum::setVariableDatums(const char* x, const int length)
+void VariableDatum::setVariableDatums(const char* x, const unsigned long length)
 {
-    if(length < 0) {
-        // *** One should really be using unsigned for size values! f.e. std::size_t
-        std::cout << " The VariableDatum pointer size parameter is negative. Punting." << std::endl;
-    }
+    // convert and store length as bits
+    _variableDatumLength = length * 8;
 
-    int byteLength = length; // why this copy?
-    _variableDatumLength = length * 8; // in bits
-
-	// Figure out padding
-    int chunks = byteLength / 8; // should be const, unsigned
-	int remainder = byteLength % 8;
-	if(remainder != 0)
+    // Figure out _arrayLength (bytes with padding (8 byte chunks))
+    unsigned long chunks = length / 8;
+    int remainder = length % 8;
+    if(remainder > 0)
 		chunks++;
     _arrayLength = chunks * 8;
 
-    int padding =  8 - remainder;
-
     // .resize() might (theoretically) throw. want to catch? : what to do? zombie datum?
-    // negative "length" would be a disaster : signed->unsigned->huge allocation
     if(_variableDatums.size() < length)
         _variableDatums.resize(length);
 
-    for(int i = 0; i < length; i++)
+    for(unsigned long i = 0; i < length; i++)
     {
         _variableDatums[i] = x[i];
     }
-    for(int i = length; i < _variableDatums.size(); i++)
+    for(unsigned long i = length; i < _variableDatums.size(); i++)
     {
         _variableDatums[i] = 0;
     }
@@ -87,7 +79,7 @@ void VariableDatum::marshal(DataStream& dataStream) const
     dataStream << _variableDatumID;
     dataStream << _variableDatumLength;
 
-    for(size_t idx = 0; idx < _arrayLength; idx++)
+    for(unsigned long idx = 0; idx < _arrayLength; idx++)
     {
         dataStream << _variableDatums[idx];
     }
@@ -98,7 +90,7 @@ void VariableDatum::unmarshal(DataStream& dataStream)
 {
     dataStream >> _variableDatumID;
     dataStream >> _variableDatumLength;
-	
+
     int byteLength = _variableDatumLength / 8;
 	int chunks = byteLength / 8;
 	if(byteLength % 8 > 0)
@@ -111,13 +103,13 @@ void VariableDatum::unmarshal(DataStream& dataStream)
     if(_variableDatums.size() < _arrayLength)
         _variableDatums.resize(_arrayLength);
 
-     for(size_t idx = 0; idx < _arrayLength; idx++)
+     for(unsigned long idx = 0; idx < _arrayLength; idx++)
      {
         dataStream >> _variableDatums[idx];
 		//std::cout << (int)_variableDatums[idx] << " ";
      }
 	 //std::cout << std::endl;
-     for(size_t idx = _arrayLength; idx < _variableDatums.size(); idx++)
+     for(unsigned long idx = _arrayLength; idx < _variableDatums.size(); idx++)
 	 {
 		 _variableDatums[idx] = 0;
 	 }
@@ -142,9 +134,9 @@ bool VariableDatum::operator ==(const VariableDatum& rhs) const
     return ivarsEqual;
 }
 
-int VariableDatum::getMarshalledSize() const
+unsigned long VariableDatum::getMarshalledSize() const
 {
-   int marshalSize = 0;
+   unsigned long marshalSize = 0;
 
    marshalSize = marshalSize + 4;  // _variableDatumID
    marshalSize = marshalSize + 4;  // _variableDatumLength

--- a/src/dis6/VariableDatum.h
+++ b/src/dis6/VariableDatum.h
@@ -20,14 +20,14 @@ class EXPORT_MACRO VariableDatum
 {
 protected:
   /** ID of the variable datum */
-  unsigned long _variableDatumID; 
+  unsigned int _variableDatumID;
 
   /** length of the variable datums */
-  unsigned long _variableDatumLength;
+  unsigned int _variableDatumLength;
 
   /** The variable datum data.*/
   std::vector<char> _variableDatums;
-  unsigned long _arrayLength;
+  unsigned int _arrayLength;
 
 
  public:
@@ -37,18 +37,18 @@ protected:
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
 
-    unsigned long getVariableDatumID() const;
-    void setVariableDatumID(unsigned long pX);
+    unsigned int getVariableDatumID() const;
+    void setVariableDatumID(unsigned int pX);
 
-    unsigned long getVariableDatumLength() const;
-    void setVariableDatumLength(unsigned long pX);
+    unsigned int getVariableDatumLength() const;
+    void setVariableDatumLength(unsigned int pX);
 
     char*  getVariableDatums();
     const char*  getVariableDatums() const;
-    void setVariableDatums(const char* pX, const unsigned long length);
+    void setVariableDatums(const char* pX, const unsigned int length);
 
 
-virtual unsigned long getMarshalledSize() const;
+virtual unsigned int getMarshalledSize() const;
 
      bool operator  ==(const VariableDatum& rhs) const;
 };

--- a/src/dis6/VariableDatum.h
+++ b/src/dis6/VariableDatum.h
@@ -20,14 +20,14 @@ class EXPORT_MACRO VariableDatum
 {
 protected:
   /** ID of the variable datum */
-  unsigned int _variableDatumID; 
+  unsigned long _variableDatumID; 
 
   /** length of the variable datums */
-  unsigned int _variableDatumLength;
+  unsigned long _variableDatumLength;
 
   /** The variable datum data.*/
   std::vector<char> _variableDatums;
-  int _arrayLength;
+  unsigned long _arrayLength;
 
 
  public:
@@ -37,18 +37,18 @@ protected:
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
 
-    unsigned int getVariableDatumID() const; 
-    void setVariableDatumID(unsigned int pX); 
+    unsigned long getVariableDatumID() const;
+    void setVariableDatumID(unsigned long pX);
 
-    unsigned int getVariableDatumLength() const; 
-    void setVariableDatumLength(unsigned int pX);
+    unsigned long getVariableDatumLength() const;
+    void setVariableDatumLength(unsigned long pX);
 
     char*  getVariableDatums();
     const char*  getVariableDatums() const;
-    void setVariableDatums(const char*    pX, const int length);
+    void setVariableDatums(const char* pX, const unsigned long length);
 
 
-virtual int getMarshalledSize() const;
+virtual unsigned long getMarshalledSize() const;
 
      bool operator  ==(const VariableDatum& rhs) const;
 };

--- a/src/dis7/ActionRequestPdu.cpp
+++ b/src/dis7/ActionRequestPdu.cpp
@@ -201,14 +201,14 @@ int ActionRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionRequestPdu.cpp
+++ b/src/dis7/ActionRequestPdu.cpp
@@ -201,14 +201,14 @@ int ActionRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionRequestReliablePdu.cpp
+++ b/src/dis7/ActionRequestReliablePdu.cpp
@@ -206,14 +206,14 @@ int ActionRequestReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionRequestReliablePdu.cpp
+++ b/src/dis7/ActionRequestReliablePdu.cpp
@@ -206,14 +206,14 @@ int ActionRequestReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionResponsePdu.cpp
+++ b/src/dis7/ActionResponsePdu.cpp
@@ -201,14 +201,14 @@ int ActionResponsePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionResponsePdu.cpp
+++ b/src/dis7/ActionResponsePdu.cpp
@@ -201,14 +201,14 @@ int ActionResponsePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionResponseReliablePdu.cpp
+++ b/src/dis7/ActionResponseReliablePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponseReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ActionResponseReliablePdu.cpp
+++ b/src/dis7/ActionResponseReliablePdu.cpp
@@ -161,14 +161,14 @@ int ActionResponseReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ArealObjectStatePdu.cpp
+++ b/src/dis7/ArealObjectStatePdu.cpp
@@ -260,7 +260,7 @@ int ArealObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _requesterID.getMarshalledSize();  // _requesterID
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
 
-   for(int idx=0; idx < _objectLocation.size(); idx++)
+   for(unsigned long idx=0; idx < _objectLocation.size(); idx++)
    {
         Vector3Double listElement = _objectLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ArealObjectStatePdu.cpp
+++ b/src/dis7/ArealObjectStatePdu.cpp
@@ -260,7 +260,7 @@ int ArealObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _requesterID.getMarshalledSize();  // _requesterID
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
 
-   for(unsigned long idx=0; idx < _objectLocation.size(); idx++)
+   for(unsigned long long idx=0; idx < _objectLocation.size(); idx++)
    {
         Vector3Double listElement = _objectLocation[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ArticulatedParts.cpp
+++ b/src/dis7/ArticulatedParts.cpp
@@ -8,7 +8,8 @@ ArticulatedParts::ArticulatedParts():
    _changeIndicator(0), 
    _partAttachedTo(0), 
    _parameterType(0), 
-   _parameterValue(0)
+   _parameterValue(0),
+   _padding(0)
 {
 }
 
@@ -56,12 +57,12 @@ void ArticulatedParts::setParameterType(unsigned int pX)
     _parameterType = pX;
 }
 
-long ArticulatedParts::getParameterValue() const
+float ArticulatedParts::getParameterValue() const
 {
     return _parameterValue;
 }
 
-void ArticulatedParts::setParameterValue(long pX)
+void ArticulatedParts::setParameterValue(float pX)
 {
     _parameterValue = pX;
 }
@@ -73,6 +74,7 @@ void ArticulatedParts::marshal(DataStream& dataStream) const
     dataStream << _partAttachedTo;
     dataStream << _parameterType;
     dataStream << _parameterValue;
+    dataStream << _padding;
 }
 
 void ArticulatedParts::unmarshal(DataStream& dataStream)
@@ -82,6 +84,7 @@ void ArticulatedParts::unmarshal(DataStream& dataStream)
     dataStream >> _partAttachedTo;
     dataStream >> _parameterType;
     dataStream >> _parameterValue;
+    dataStream >> _padding;
 }
 
 
@@ -106,7 +109,8 @@ int ArticulatedParts::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _changeIndicator
    marshalSize = marshalSize + 2;  // _partAttachedTo
    marshalSize = marshalSize + 4;  // _parameterType
-   marshalSize = marshalSize + 8;  // _parameterValue
+   marshalSize = marshalSize + 4;  // _parameterValue
+   marshalSize = marshalSize + 4;  // _padding
     return marshalSize;
 }
 

--- a/src/dis7/ArticulatedParts.h
+++ b/src/dis7/ArticulatedParts.h
@@ -7,7 +7,7 @@
 
 namespace DIS
 {
-//  articulated parts for movable parts and a combination of moveable/attached parts of an entity. Section 6.2.93.2
+//  articulated parts for movable parts and a combination of moveable/attached parts of an entity. Section 6.2.94.2
 
 // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
 //
@@ -28,8 +28,12 @@ protected:
   /** the type of parameter represented, 32 bit enumeration */
   unsigned int _parameterType; 
 
-  /** The definition of the 64 bits shall be determined based on the type of parameter specified in the Parameter Type field  */
-  long _parameterValue; 
+  /** This field shall specify the parameter value and shall be specified by a 32-bit
+floating point number.  */
+  float _parameterValue;
+
+  /** 32 bits of unused padding */
+  unsigned int _padding;
 
 
  public:
@@ -51,8 +55,8 @@ protected:
     unsigned int getParameterType() const; 
     void setParameterType(unsigned int pX); 
 
-    long getParameterValue() const; 
-    void setParameterValue(long pX); 
+    float getParameterValue() const;
+    void setParameterValue(float pX);
 
 
 virtual int getMarshalledSize() const;

--- a/src/dis7/AttachedParts.cpp
+++ b/src/dis7/AttachedParts.cpp
@@ -8,7 +8,7 @@ AttachedParts::AttachedParts():
    _detachedIndicator(0), 
    _partAttachedTo(0), 
    _parameterType(0), 
-   _parameterValue(0)
+   _attachedPartType(0)
 {
 }
 
@@ -56,14 +56,14 @@ void AttachedParts::setParameterType(unsigned int pX)
     _parameterType = pX;
 }
 
-long AttachedParts::getParameterValue() const
+unsigned long long AttachedParts::getAttachedPartType() const
 {
-    return _parameterValue;
+    return _attachedPartType;
 }
 
-void AttachedParts::setParameterValue(long pX)
+void AttachedParts::setAttachedPartType(unsigned long long pX)
 {
-    _parameterValue = pX;
+    _attachedPartType = pX;
 }
 
 void AttachedParts::marshal(DataStream& dataStream) const
@@ -72,7 +72,7 @@ void AttachedParts::marshal(DataStream& dataStream) const
     dataStream << _detachedIndicator;
     dataStream << _partAttachedTo;
     dataStream << _parameterType;
-    dataStream << _parameterValue;
+    dataStream << _attachedPartType;
 }
 
 void AttachedParts::unmarshal(DataStream& dataStream)
@@ -81,7 +81,7 @@ void AttachedParts::unmarshal(DataStream& dataStream)
     dataStream >> _detachedIndicator;
     dataStream >> _partAttachedTo;
     dataStream >> _parameterType;
-    dataStream >> _parameterValue;
+    dataStream >> _attachedPartType;
 }
 
 
@@ -93,7 +93,7 @@ bool AttachedParts::operator ==(const AttachedParts& rhs) const
      if( ! (_detachedIndicator == rhs._detachedIndicator) ) ivarsEqual = false;
      if( ! (_partAttachedTo == rhs._partAttachedTo) ) ivarsEqual = false;
      if( ! (_parameterType == rhs._parameterType) ) ivarsEqual = false;
-     if( ! (_parameterValue == rhs._parameterValue) ) ivarsEqual = false;
+     if( ! (_attachedPartType == rhs._attachedPartType) ) ivarsEqual = false;
 
     return ivarsEqual;
  }
@@ -106,7 +106,7 @@ int AttachedParts::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _detachedIndicator
    marshalSize = marshalSize + 2;  // _partAttachedTo
    marshalSize = marshalSize + 4;  // _parameterType
-   marshalSize = marshalSize + 8;  // _parameterValue
+   marshalSize = marshalSize + 8;  // _attachedPartType
     return marshalSize;
 }
 

--- a/src/dis7/AttachedParts.h
+++ b/src/dis7/AttachedParts.h
@@ -7,7 +7,7 @@
 
 namespace DIS
 {
-// Removable parts that may be attached to an entity.  Section 6.2.93.3
+// Removable parts that may be attached to an entity.  Section 6.2.94.3
 
 // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
 //
@@ -29,7 +29,7 @@ protected:
   unsigned int _parameterType; 
 
   /** The definition of the 64 bits shall be determined based on the type of parameter specified in the Parameter Type field  */
-  long _parameterValue; 
+  unsigned long long _attachedPartType;
 
 
  public:
@@ -51,8 +51,8 @@ protected:
     unsigned int getParameterType() const; 
     void setParameterType(unsigned int pX); 
 
-    long getParameterValue() const; 
-    void setParameterValue(long pX); 
+    unsigned long long getAttachedPartType() const;
+    void setAttachedPartType(unsigned long long pX);
 
 
 virtual int getMarshalledSize() const;

--- a/src/dis7/Attribute.cpp
+++ b/src/dis7/Attribute.cpp
@@ -24,22 +24,22 @@ void Attribute::setRecordType(unsigned int pX)
     _recordType = pX;
 }
 
-unsigned char Attribute::getRecordLength() const
+unsigned short Attribute::getRecordLength() const
 {
     return _recordLength;
 }
 
-void Attribute::setRecordLength(unsigned char pX)
+void Attribute::setRecordLength(unsigned short pX)
 {
     _recordLength = pX;
 }
 
-long Attribute::getRecordSpecificFields() const
+long long Attribute::getRecordSpecificFields() const
 {
     return _recordSpecificFields;
 }
 
-void Attribute::setRecordSpecificFields(long pX)
+void Attribute::setRecordSpecificFields(long long pX)
 {
     _recordSpecificFields = pX;
 }

--- a/src/dis7/Attribute.h
+++ b/src/dis7/Attribute.h
@@ -7,7 +7,7 @@
 
 namespace DIS
 {
-// Used to convey information for one or more attributes. Attributes conform to the standard variable record format of 6.2.82. Section 6.2.11
+// Used to convey information for one or more attributes. Attributes conform to the standard variable record format of 6.2.82. Section 6.2.10
 
 // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
 //
@@ -18,9 +18,9 @@ class EXPORT_MACRO Attribute
 protected:
   unsigned int _recordType; 
 
-  unsigned char _recordLength; 
+  unsigned short _recordLength;
 
-  long _recordSpecificFields; 
+  long long _recordSpecificFields;
 
 
  public:
@@ -33,11 +33,11 @@ protected:
     unsigned int getRecordType() const; 
     void setRecordType(unsigned int pX); 
 
-    unsigned char getRecordLength() const; 
-    void setRecordLength(unsigned char pX); 
+    unsigned short getRecordLength() const;
+    void setRecordLength(unsigned short pX);
 
-    long getRecordSpecificFields() const; 
-    void setRecordSpecificFields(long pX); 
+    long long getRecordSpecificFields() const;
+    void setRecordSpecificFields(long long pX);
 
 
 virtual int getMarshalledSize() const;

--- a/src/dis7/CommentPdu.cpp
+++ b/src/dis7/CommentPdu.cpp
@@ -131,14 +131,14 @@ int CommentPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/CommentPdu.cpp
+++ b/src/dis7/CommentPdu.cpp
@@ -131,14 +131,14 @@ int CommentPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/CommentReliablePdu.cpp
+++ b/src/dis7/CommentReliablePdu.cpp
@@ -131,14 +131,14 @@ int CommentReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/CommentReliablePdu.cpp
+++ b/src/dis7/CommentReliablePdu.cpp
@@ -131,14 +131,14 @@ int CommentReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataPdu.cpp
+++ b/src/dis7/DataPdu.cpp
@@ -161,14 +161,14 @@ int DataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataPdu.cpp
+++ b/src/dis7/DataPdu.cpp
@@ -161,14 +161,14 @@ int DataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryDatumSpecification.cpp
+++ b/src/dis7/DataQueryDatumSpecification.cpp
@@ -125,14 +125,14 @@ int DataQueryDatumSpecification::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatums
    marshalSize = marshalSize + 4;  // _numberOfVariableDatums
 
-   for(int idx=0; idx < _fixedDatumIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumIDList.size(); idx++)
    {
         UnsignedDISInteger listElement = _fixedDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumIDList.size(); idx++)
    {
         UnsignedDISInteger listElement = _variableDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryDatumSpecification.cpp
+++ b/src/dis7/DataQueryDatumSpecification.cpp
@@ -125,14 +125,14 @@ int DataQueryDatumSpecification::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatums
    marshalSize = marshalSize + 4;  // _numberOfVariableDatums
 
-   for(unsigned long idx=0; idx < _fixedDatumIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumIDList.size(); idx++)
    {
         UnsignedDISInteger listElement = _fixedDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumIDList.size(); idx++)
    {
         UnsignedDISInteger listElement = _variableDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryPdu.cpp
+++ b/src/dis7/DataQueryPdu.cpp
@@ -161,14 +161,14 @@ int DataQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryPdu.cpp
+++ b/src/dis7/DataQueryPdu.cpp
@@ -161,14 +161,14 @@ int DataQueryPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryReliablePdu.cpp
+++ b/src/dis7/DataQueryReliablePdu.cpp
@@ -206,14 +206,14 @@ int DataQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataQueryReliablePdu.cpp
+++ b/src/dis7/DataQueryReliablePdu.cpp
@@ -206,14 +206,14 @@ int DataQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataReliablePdu.cpp
+++ b/src/dis7/DataReliablePdu.cpp
@@ -191,14 +191,14 @@ int DataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DataReliablePdu.cpp
+++ b/src/dis7/DataReliablePdu.cpp
@@ -191,14 +191,14 @@ int DataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DatumSpecification.cpp
+++ b/src/dis7/DatumSpecification.cpp
@@ -125,14 +125,14 @@ int DatumSpecification::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatums
    marshalSize = marshalSize + 4;  // _numberOfVariableDatums
 
-   for(unsigned long idx=0; idx < _fixedDatumIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumIDList.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumIDList.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumIDList.size(); idx++)
    {
         VariableDatum listElement = _variableDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DatumSpecification.cpp
+++ b/src/dis7/DatumSpecification.cpp
@@ -125,14 +125,14 @@ int DatumSpecification::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatums
    marshalSize = marshalSize + 4;  // _numberOfVariableDatums
 
-   for(int idx=0; idx < _fixedDatumIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumIDList.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumIDList.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumIDList.size(); idx++)
    {
         VariableDatum listElement = _variableDatumIDList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DetonationPdu.cpp
+++ b/src/dis7/DetonationPdu.cpp
@@ -235,7 +235,7 @@ int DetonationPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfVariableParameters
    marshalSize = marshalSize + 2;  // _pad
 
-   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DetonationPdu.cpp
+++ b/src/dis7/DetonationPdu.cpp
@@ -235,7 +235,7 @@ int DetonationPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfVariableParameters
    marshalSize = marshalSize + 2;  // _pad
 
-   for(int idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DirectedEnergyAreaAimpoint.cpp
+++ b/src/dis7/DirectedEnergyAreaAimpoint.cpp
@@ -170,14 +170,14 @@ int DirectedEnergyAreaAimpoint::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _beamAntennaPatternRecordCount
    marshalSize = marshalSize + 2;  // _directedEnergyTargetEnergyDepositionRecordCount
 
-   for(unsigned long idx=0; idx < _beamAntennaParameterList.size(); idx++)
+   for(unsigned long long idx=0; idx < _beamAntennaParameterList.size(); idx++)
    {
         BeamAntennaPattern listElement = _beamAntennaParameterList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _directedEnergyTargetEnergyDepositionRecordList.size(); idx++)
+   for(unsigned long long idx=0; idx < _directedEnergyTargetEnergyDepositionRecordList.size(); idx++)
    {
         DirectedEnergyTargetEnergyDeposition listElement = _directedEnergyTargetEnergyDepositionRecordList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DirectedEnergyAreaAimpoint.cpp
+++ b/src/dis7/DirectedEnergyAreaAimpoint.cpp
@@ -170,14 +170,14 @@ int DirectedEnergyAreaAimpoint::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _beamAntennaPatternRecordCount
    marshalSize = marshalSize + 2;  // _directedEnergyTargetEnergyDepositionRecordCount
 
-   for(int idx=0; idx < _beamAntennaParameterList.size(); idx++)
+   for(unsigned long idx=0; idx < _beamAntennaParameterList.size(); idx++)
    {
         BeamAntennaPattern listElement = _beamAntennaParameterList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _directedEnergyTargetEnergyDepositionRecordList.size(); idx++)
+   for(unsigned long idx=0; idx < _directedEnergyTargetEnergyDepositionRecordList.size(); idx++)
    {
         DirectedEnergyTargetEnergyDeposition listElement = _directedEnergyTargetEnergyDepositionRecordList[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DirectedEnergyFirePdu.cpp
+++ b/src/dis7/DirectedEnergyFirePdu.cpp
@@ -310,7 +310,7 @@ int DirectedEnergyFirePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding3
    marshalSize = marshalSize + 2;  // _numberOfDERecords
 
-   for(unsigned long idx=0; idx < _dERecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _dERecords.size(); idx++)
    {
         StandardVariableSpecification listElement = _dERecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/DirectedEnergyFirePdu.cpp
+++ b/src/dis7/DirectedEnergyFirePdu.cpp
@@ -310,7 +310,7 @@ int DirectedEnergyFirePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding3
    marshalSize = marshalSize + 2;  // _numberOfDERecords
 
-   for(int idx=0; idx < _dERecords.size(); idx++)
+   for(unsigned long idx=0; idx < _dERecords.size(); idx++)
    {
         StandardVariableSpecification listElement = _dERecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EightByteChunk.cpp
+++ b/src/dis7/EightByteChunk.cpp
@@ -61,7 +61,7 @@ bool EightByteChunk::operator ==(const EightByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 8; idx++)
+     for(unsigned char idx = 0; idx < 8; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis7/ElectronicEmissionsPdu.cpp
+++ b/src/dis7/ElectronicEmissionsPdu.cpp
@@ -226,7 +226,7 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
    marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
-   for(unsigned long idx=0; idx < _systems.size(); idx++)
+   for(unsigned long long idx=0; idx < _systems.size(); idx++)
    {
         Vector3Float listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ElectronicEmissionsPdu.cpp
+++ b/src/dis7/ElectronicEmissionsPdu.cpp
@@ -226,7 +226,7 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
    marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
-   for(int idx=0; idx < _systems.size(); idx++)
+   for(unsigned long idx=0; idx < _systems.size(); idx++)
    {
         Vector3Float listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityDamageStatusPdu.cpp
+++ b/src/dis7/EntityDamageStatusPdu.cpp
@@ -135,7 +135,7 @@ int EntityDamageStatusPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding2
    marshalSize = marshalSize + 2;  // _numberOfDamageDescription
 
-   for(int idx=0; idx < _damageDescriptionRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _damageDescriptionRecords.size(); idx++)
    {
         DirectedEnergyDamage listElement = _damageDescriptionRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityDamageStatusPdu.cpp
+++ b/src/dis7/EntityDamageStatusPdu.cpp
@@ -135,7 +135,7 @@ int EntityDamageStatusPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding2
    marshalSize = marshalSize + 2;  // _numberOfDamageDescription
 
-   for(unsigned long idx=0; idx < _damageDescriptionRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _damageDescriptionRecords.size(); idx++)
    {
         DirectedEnergyDamage listElement = _damageDescriptionRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityMarking.cpp
+++ b/src/dis7/EntityMarking.cpp
@@ -84,7 +84,7 @@ bool EntityMarking::operator ==(const EntityMarking& rhs) const
 
      if( ! (_characterSet == rhs._characterSet) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 11; idx++)
+     for(unsigned char idx = 0; idx < 11; idx++)
      {
           if(!(_characters[idx] == rhs._characters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis7/EntityStatePdu.cpp
+++ b/src/dis7/EntityStatePdu.cpp
@@ -290,7 +290,7 @@ int EntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _marking.getMarshalledSize();  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(int idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityStatePdu.cpp
+++ b/src/dis7/EntityStatePdu.cpp
@@ -290,7 +290,7 @@ int EntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _marking.getMarshalledSize();  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityStateUpdatePdu.cpp
+++ b/src/dis7/EntityStateUpdatePdu.cpp
@@ -196,7 +196,7 @@ int EntityStateUpdatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _entityOrientation.getMarshalledSize();  // _entityOrientation
    marshalSize = marshalSize + 4;  // _entityAppearance
 
-   for(int idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EntityStateUpdatePdu.cpp
+++ b/src/dis7/EntityStateUpdatePdu.cpp
@@ -196,7 +196,7 @@ int EntityStateUpdatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _entityOrientation.getMarshalledSize();  // _entityOrientation
    marshalSize = marshalSize + 4;  // _entityAppearance
 
-   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EventReportPdu.cpp
+++ b/src/dis7/EventReportPdu.cpp
@@ -161,14 +161,14 @@ int EventReportPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EventReportPdu.cpp
+++ b/src/dis7/EventReportPdu.cpp
@@ -161,14 +161,14 @@ int EventReportPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EventReportReliablePdu.cpp
+++ b/src/dis7/EventReportReliablePdu.cpp
@@ -161,14 +161,14 @@ int EventReportReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/EventReportReliablePdu.cpp
+++ b/src/dis7/EventReportReliablePdu.cpp
@@ -161,14 +161,14 @@ int EventReportReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ExpendableDescriptor.cpp
+++ b/src/dis7/ExpendableDescriptor.cpp
@@ -28,12 +28,12 @@ void ExpendableDescriptor::setExpendableType(const EntityType &pX)
     _expendableType = pX;
 }
 
-long ExpendableDescriptor::getPadding() const
+long long ExpendableDescriptor::getPadding() const
 {
     return _padding;
 }
 
-void ExpendableDescriptor::setPadding(long pX)
+void ExpendableDescriptor::setPadding(long long pX)
 {
     _padding = pX;
 }

--- a/src/dis7/ExpendableDescriptor.h
+++ b/src/dis7/ExpendableDescriptor.h
@@ -21,7 +21,7 @@ protected:
   EntityType _expendableType; 
 
   /** Padding */
-  long _padding; 
+  long long _padding;
 
 
  public:
@@ -35,8 +35,8 @@ protected:
     const EntityType&  getExpendableType() const; 
     void setExpendableType(const EntityType    &pX);
 
-    long getPadding() const; 
-    void setPadding(long pX); 
+    long long getPadding() const;
+    void setPadding(long long pX);
 
 
 virtual int getMarshalledSize() const;

--- a/src/dis7/FastEntityStatePdu.cpp
+++ b/src/dis7/FastEntityStatePdu.cpp
@@ -720,7 +720,7 @@ int FastEntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 12 * 1;  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/FastEntityStatePdu.cpp
+++ b/src/dis7/FastEntityStatePdu.cpp
@@ -647,7 +647,7 @@ bool FastEntityStatePdu::operator ==(const FastEntityStatePdu& rhs) const
      if( ! (_entityAppearance == rhs._entityAppearance) ) ivarsEqual = false;
      if( ! (_deadReckoningAlgorithm == rhs._deadReckoningAlgorithm) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 15; idx++)
+     for(unsigned char idx = 0; idx < 15; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }
@@ -659,7 +659,7 @@ bool FastEntityStatePdu::operator ==(const FastEntityStatePdu& rhs) const
      if( ! (_yAngularVelocity == rhs._yAngularVelocity) ) ivarsEqual = false;
      if( ! (_zAngularVelocity == rhs._zAngularVelocity) ) ivarsEqual = false;
 
-     for(char idx = 0; idx < 12; idx++)
+     for(unsigned char idx = 0; idx < 12; idx++)
      {
           if(!(_marking[idx] == rhs._marking[idx]) ) ivarsEqual = false;
      }
@@ -720,7 +720,7 @@ int FastEntityStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 12 * 1;  // _marking
    marshalSize = marshalSize + 4;  // _capabilities
 
-   for(int idx=0; idx < _variableParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _variableParameters.size(); idx++)
    {
         VariableParameter listElement = _variableParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/FastEntityStatePdu.h
+++ b/src/dis7/FastEntityStatePdu.h
@@ -32,7 +32,7 @@ protected:
   unsigned char _forceId; 
 
   /** How many variable (nee articulation) parameters are in the variable length list */
-  char _numberOfVariableParameters; 
+  unsigned char _numberOfVariableParameters; 
 
   /** Kind of entity */
   unsigned char _entityKind; 

--- a/src/dis7/FourByteChunk.cpp
+++ b/src/dis7/FourByteChunk.cpp
@@ -61,7 +61,7 @@ bool FourByteChunk::operator ==(const FourByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 4; idx++)
+     for(unsigned char idx = 0; idx < 4; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis7/IntercomSignalPdu.cpp
+++ b/src/dis7/IntercomSignalPdu.cpp
@@ -180,7 +180,7 @@ int IntercomSignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(unsigned long idx=0; idx < _data.size(); idx++)
+   for(unsigned long long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/IntercomSignalPdu.cpp
+++ b/src/dis7/IntercomSignalPdu.cpp
@@ -180,7 +180,7 @@ int IntercomSignalPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _dataLength
    marshalSize = marshalSize + 2;  // _samples
 
-   for(int idx=0; idx < _data.size(); idx++)
+   for(unsigned long idx=0; idx < _data.size(); idx++)
    {
         OneByteChunk listElement = _data[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/LinearObjectStatePdu.cpp
+++ b/src/dis7/LinearObjectStatePdu.cpp
@@ -215,7 +215,7 @@ int LinearObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + _objectType.getMarshalledSize();  // _objectType
 
-   for(int idx=0; idx < _linearSegmentParameters.size(); idx++)
+   for(unsigned long idx=0; idx < _linearSegmentParameters.size(); idx++)
    {
         LinearSegmentParameter listElement = _linearSegmentParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/LinearObjectStatePdu.cpp
+++ b/src/dis7/LinearObjectStatePdu.cpp
@@ -215,7 +215,7 @@ int LinearObjectStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + _objectType.getMarshalledSize();  // _objectType
 
-   for(unsigned long idx=0; idx < _linearSegmentParameters.size(); idx++)
+   for(unsigned long long idx=0; idx < _linearSegmentParameters.size(); idx++)
    {
         LinearSegmentParameter listElement = _linearSegmentParameters[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/MinefieldResponseNackPdu.cpp
+++ b/src/dis7/MinefieldResponseNackPdu.cpp
@@ -140,7 +140,7 @@ int MinefieldResponseNackPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _requestID
    marshalSize = marshalSize + 1;  // _numberOfMissingPdus
 
-   for(int idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
+   for(unsigned long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
    {
         EightByteChunk listElement = _missingPduSequenceNumbers[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/MinefieldResponseNackPdu.cpp
+++ b/src/dis7/MinefieldResponseNackPdu.cpp
@@ -140,7 +140,7 @@ int MinefieldResponseNackPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _requestID
    marshalSize = marshalSize + 1;  // _numberOfMissingPdus
 
-   for(unsigned long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
+   for(unsigned long long idx=0; idx < _missingPduSequenceNumbers.size(); idx++)
    {
         EightByteChunk listElement = _missingPduSequenceNumbers[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/MinefieldStatePdu.cpp
+++ b/src/dis7/MinefieldStatePdu.cpp
@@ -271,14 +271,14 @@ int MinefieldStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _appearance
    marshalSize = marshalSize + 2;  // _protocolMode
 
-   for(int idx=0; idx < _perimeterPoints.size(); idx++)
+   for(unsigned long idx=0; idx < _perimeterPoints.size(); idx++)
    {
         Vector2Float listElement = _perimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _mineType.size(); idx++)
+   for(unsigned long idx=0; idx < _mineType.size(); idx++)
    {
         EntityType listElement = _mineType[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/MinefieldStatePdu.cpp
+++ b/src/dis7/MinefieldStatePdu.cpp
@@ -271,14 +271,14 @@ int MinefieldStatePdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _appearance
    marshalSize = marshalSize + 2;  // _protocolMode
 
-   for(unsigned long idx=0; idx < _perimeterPoints.size(); idx++)
+   for(unsigned long long idx=0; idx < _perimeterPoints.size(); idx++)
    {
         Vector2Float listElement = _perimeterPoints[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _mineType.size(); idx++)
+   for(unsigned long long idx=0; idx < _mineType.size(); idx++)
    {
         EntityType listElement = _mineType[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/OneByteChunk.cpp
+++ b/src/dis7/OneByteChunk.cpp
@@ -47,27 +47,13 @@ void OneByteChunk::marshal(DataStream& dataStream) const
 
 void OneByteChunk::unmarshal(DataStream& dataStream)
 {
-
-     for(size_t idx = 0; idx < 1; idx++)
-     {
-        dataStream >> _otherParameters[idx];
-     }
-
+        dataStream >> _otherParameters[0];
 }
 
 
 bool OneByteChunk::operator ==(const OneByteChunk& rhs) const
  {
-     bool ivarsEqual = true;
-
-
-     for(char idx = 0; idx < 1; idx++)
-     {
-          if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
-     }
-
-
-    return ivarsEqual;
+     return (_otherParameters[0] == rhs._otherParameters[0]);
  }
 
 int OneByteChunk::getMarshalledSize() const

--- a/src/dis7/PduContainer.cpp
+++ b/src/dis7/PduContainer.cpp
@@ -13,7 +13,7 @@ PduContainer::~PduContainer()
     _pdus.clear();
 }
 
-int PduContainer::getNumberOfPdus() const
+unsigned int PduContainer::getNumberOfPdus() const
 {
    return _pdus.size();
 }
@@ -79,7 +79,7 @@ int PduContainer::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfPdus
 
-   for(int idx=0; idx < _pdus.size(); idx++)
+   for(unsigned long idx=0; idx < _pdus.size(); idx++)
    {
         Pdu listElement = _pdus[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/PduContainer.cpp
+++ b/src/dis7/PduContainer.cpp
@@ -79,7 +79,7 @@ int PduContainer::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfPdus
 
-   for(unsigned long idx=0; idx < _pdus.size(); idx++)
+   for(unsigned long long idx=0; idx < _pdus.size(); idx++)
    {
         Pdu listElement = _pdus[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/PduContainer.h
+++ b/src/dis7/PduContainer.h
@@ -19,7 +19,7 @@ class EXPORT_MACRO PduContainer
 {
 protected:
   /** Number of PDUs in the container list */
-  int _numberOfPdus; 
+  unsigned int _numberOfPdus; 
 
   /** record sets */
   std::vector<Pdu> _pdus; 
@@ -32,7 +32,7 @@ protected:
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
 
-    int getNumberOfPdus() const; 
+    unsigned int getNumberOfPdus() const; 
 
     std::vector<Pdu>& getPdus(); 
     const std::vector<Pdu>& getPdus() const; 

--- a/src/dis7/RecordQueryReliablePdu.cpp
+++ b/src/dis7/RecordQueryReliablePdu.cpp
@@ -175,7 +175,7 @@ int RecordQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _time
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(int idx=0; idx < _recordIDs.size(); idx++)
+   for(unsigned long idx=0; idx < _recordIDs.size(); idx++)
    {
         FourByteChunk listElement = _recordIDs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/RecordQueryReliablePdu.cpp
+++ b/src/dis7/RecordQueryReliablePdu.cpp
@@ -175,7 +175,7 @@ int RecordQueryReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _time
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(unsigned long idx=0; idx < _recordIDs.size(); idx++)
+   for(unsigned long long idx=0; idx < _recordIDs.size(); idx++)
    {
         FourByteChunk listElement = _recordIDs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/RecordQuerySpecification.cpp
+++ b/src/dis7/RecordQuerySpecification.cpp
@@ -79,7 +79,7 @@ int RecordQuerySpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(unsigned long idx=0; idx < _records.size(); idx++)
+   for(unsigned long long idx=0; idx < _records.size(); idx++)
    {
         FourByteChunk listElement = _records[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/RecordQuerySpecification.cpp
+++ b/src/dis7/RecordQuerySpecification.cpp
@@ -79,7 +79,7 @@ int RecordQuerySpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfRecords
 
-   for(int idx=0; idx < _records.size(); idx++)
+   for(unsigned long idx=0; idx < _records.size(); idx++)
    {
         FourByteChunk listElement = _records[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/RecordSpecification.cpp
+++ b/src/dis7/RecordSpecification.cpp
@@ -79,7 +79,7 @@ int RecordSpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfRecordSets
 
-   for(int idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSpecificationElement listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/RecordSpecification.cpp
+++ b/src/dis7/RecordSpecification.cpp
@@ -79,7 +79,7 @@ int RecordSpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 4;  // _numberOfRecordSets
 
-   for(unsigned long idx=0; idx < _recordSets.size(); idx++)
+   for(unsigned long long idx=0; idx < _recordSets.size(); idx++)
    {
         RecordSpecificationElement listElement = _recordSets[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ResupplyOfferPdu.cpp
+++ b/src/dis7/ResupplyOfferPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyOfferPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _padding1
    marshalSize = marshalSize + 2;  // _padding2
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ResupplyOfferPdu.cpp
+++ b/src/dis7/ResupplyOfferPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyOfferPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _padding1
    marshalSize = marshalSize + 2;  // _padding2
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ResupplyReceivedPdu.cpp
+++ b/src/dis7/ResupplyReceivedPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyReceivedPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ResupplyReceivedPdu.cpp
+++ b/src/dis7/ResupplyReceivedPdu.cpp
@@ -155,7 +155,7 @@ int ResupplyReceivedPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _padding1
    marshalSize = marshalSize + 1;  // _padding2
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SeesPdu.cpp
+++ b/src/dis7/SeesPdu.cpp
@@ -196,14 +196,14 @@ int SeesPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfPropulsionSystems
    marshalSize = marshalSize + 2;  // _numberOfVectoringNozzleSystems
 
-   for(unsigned long idx=0; idx < _propulsionSystemData.size(); idx++)
+   for(unsigned long long idx=0; idx < _propulsionSystemData.size(); idx++)
    {
         PropulsionSystemData listElement = _propulsionSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _vectoringSystemData.size(); idx++)
+   for(unsigned long long idx=0; idx < _vectoringSystemData.size(); idx++)
    {
         VectoringNozzleSystem listElement = _vectoringSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SeesPdu.cpp
+++ b/src/dis7/SeesPdu.cpp
@@ -196,14 +196,14 @@ int SeesPdu::getMarshalledSize() const
    marshalSize = marshalSize + 2;  // _numberOfPropulsionSystems
    marshalSize = marshalSize + 2;  // _numberOfVectoringNozzleSystems
 
-   for(int idx=0; idx < _propulsionSystemData.size(); idx++)
+   for(unsigned long idx=0; idx < _propulsionSystemData.size(); idx++)
    {
         PropulsionSystemData listElement = _propulsionSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _vectoringSystemData.size(); idx++)
+   for(unsigned long idx=0; idx < _vectoringSystemData.size(); idx++)
    {
         VectoringNozzleSystem listElement = _vectoringSystemData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ServiceRequestPdu.cpp
+++ b/src/dis7/ServiceRequestPdu.cpp
@@ -155,7 +155,7 @@ int ServiceRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSupplyTypes
    marshalSize = marshalSize + 2;  // _serviceRequestPadding
 
-   for(unsigned long idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/ServiceRequestPdu.cpp
+++ b/src/dis7/ServiceRequestPdu.cpp
@@ -155,7 +155,7 @@ int ServiceRequestPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfSupplyTypes
    marshalSize = marshalSize + 2;  // _serviceRequestPadding
 
-   for(int idx=0; idx < _supplies.size(); idx++)
+   for(unsigned long idx=0; idx < _supplies.size(); idx++)
    {
         SupplyQuantity listElement = _supplies[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SetDataPdu.cpp
+++ b/src/dis7/SetDataPdu.cpp
@@ -161,14 +161,14 @@ int SetDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SetDataPdu.cpp
+++ b/src/dis7/SetDataPdu.cpp
@@ -161,14 +161,14 @@ int SetDataPdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatums.size(); idx++)
    {
         FixedDatum listElement = _fixedDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatums.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatums.size(); idx++)
    {
         VariableDatum listElement = _variableDatums[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SetDataReliablePdu.cpp
+++ b/src/dis7/SetDataReliablePdu.cpp
@@ -191,14 +191,14 @@ int SetDataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(int idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/SetDataReliablePdu.cpp
+++ b/src/dis7/SetDataReliablePdu.cpp
@@ -191,14 +191,14 @@ int SetDataReliablePdu::getMarshalledSize() const
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords
    marshalSize = marshalSize + 4;  // _numberOfVariableDatumRecords
 
-   for(unsigned long idx=0; idx < _fixedDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _fixedDatumRecords.size(); idx++)
    {
         FixedDatum listElement = _fixedDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _variableDatumRecords.size(); idx++)
+   for(unsigned long long idx=0; idx < _variableDatumRecords.size(); idx++)
    {
         VariableDatum listElement = _variableDatumRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/StandardVariableSpecification.cpp
+++ b/src/dis7/StandardVariableSpecification.cpp
@@ -79,7 +79,7 @@ int StandardVariableSpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 2;  // _numberOfStandardVariableRecords
 
-   for(unsigned long idx=0; idx < _standardVariables.size(); idx++)
+   for(unsigned long long idx=0; idx < _standardVariables.size(); idx++)
    {
         SimulationManagementPduHeader listElement = _standardVariables[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/StandardVariableSpecification.cpp
+++ b/src/dis7/StandardVariableSpecification.cpp
@@ -79,7 +79,7 @@ int StandardVariableSpecification::getMarshalledSize() const
 
    marshalSize = marshalSize + 2;  // _numberOfStandardVariableRecords
 
-   for(int idx=0; idx < _standardVariables.size(); idx++)
+   for(unsigned long idx=0; idx < _standardVariables.size(); idx++)
    {
         SimulationManagementPduHeader listElement = _standardVariables[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/TwoByteChunk.cpp
+++ b/src/dis7/TwoByteChunk.cpp
@@ -61,7 +61,7 @@ bool TwoByteChunk::operator ==(const TwoByteChunk& rhs) const
      bool ivarsEqual = true;
 
 
-     for(char idx = 0; idx < 2; idx++)
+     for(unsigned char idx = 0; idx < 2; idx++)
      {
           if(!(_otherParameters[idx] == rhs._otherParameters[idx]) ) ivarsEqual = false;
      }

--- a/src/dis7/UaPdu.cpp
+++ b/src/dis7/UaPdu.cpp
@@ -277,21 +277,21 @@ int UaPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfAPAs
    marshalSize = marshalSize + 1;  // _numberOfUAEmitterSystems
 
-   for(int idx=0; idx < _shaftRPMs.size(); idx++)
+   for(unsigned long idx=0; idx < _shaftRPMs.size(); idx++)
    {
         Vector3Float listElement = _shaftRPMs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _apaData.size(); idx++)
+   for(unsigned long idx=0; idx < _apaData.size(); idx++)
    {
         Vector3Float listElement = _apaData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(int idx=0; idx < _emitterSystems.size(); idx++)
+   for(unsigned long idx=0; idx < _emitterSystems.size(); idx++)
    {
         Vector3Float listElement = _emitterSystems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/UaPdu.cpp
+++ b/src/dis7/UaPdu.cpp
@@ -277,21 +277,21 @@ int UaPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _numberOfAPAs
    marshalSize = marshalSize + 1;  // _numberOfUAEmitterSystems
 
-   for(unsigned long idx=0; idx < _shaftRPMs.size(); idx++)
+   for(unsigned long long idx=0; idx < _shaftRPMs.size(); idx++)
    {
         Vector3Float listElement = _shaftRPMs[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _apaData.size(); idx++)
+   for(unsigned long long idx=0; idx < _apaData.size(); idx++)
    {
         Vector3Float listElement = _apaData[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 
 
-   for(unsigned long idx=0; idx < _emitterSystems.size(); idx++)
+   for(unsigned long long idx=0; idx < _emitterSystems.size(); idx++)
    {
         Vector3Float listElement = _emitterSystems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();

--- a/src/dis7/VariableDatum.h
+++ b/src/dis7/VariableDatum.h
@@ -3,6 +3,8 @@
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
+#include <dis7/EightByteChunk.h>
+#include <vector>
 
 
 namespace DIS
@@ -27,6 +29,9 @@ protected:
 
   /** padding to put the record on a 64 bit boundary */
   unsigned int _padding; 
+
+  // Variable Data
+  std::vector<EightByteChunk> _variableDatums;
 
 
  public:

--- a/src/utils/DataStream.cpp
+++ b/src/utils/DataStream.cpp
@@ -198,13 +198,13 @@ DataStream& DataStream::operator <<(unsigned int d)
    return *this;
 }
 
-DataStream& DataStream::operator <<(long d)
+DataStream& DataStream::operator <<(long long d)
 {
    WriteAlgorithm( d );
    return *this;
 }
 
-DataStream& DataStream::operator <<(unsigned long d)
+DataStream& DataStream::operator <<(unsigned long long d)
 {
    WriteAlgorithm( d );
    return *this;
@@ -259,13 +259,13 @@ DataStream& DataStream::operator >>(unsigned int& d)
    return *this;
 }
 
-DataStream& DataStream::operator >>(long& d)
+DataStream& DataStream::operator >>(long long& d)
 {
    ReadAlgorithm( d );
    return *this;
 }
 
-DataStream& DataStream::operator >>(unsigned long& d)
+DataStream& DataStream::operator >>(unsigned long long& d)
 {
    ReadAlgorithm( d );
    return *this;

--- a/src/utils/DataStream.h
+++ b/src/utils/DataStream.h
@@ -55,8 +55,8 @@ namespace DIS
       DataStream& operator <<(double c);
       DataStream& operator <<(int c);
       DataStream& operator <<(unsigned int c);
-      DataStream& operator <<(long c);
-      DataStream& operator <<(unsigned long c);
+      DataStream& operator <<(long long c);
+      DataStream& operator <<(unsigned long long c);
       DataStream& operator <<(unsigned short c);
       DataStream& operator <<(short c);
 
@@ -68,8 +68,8 @@ namespace DIS
       DataStream& operator >>(double& c);
       DataStream& operator >>(int& c);
       DataStream& operator >>(unsigned int& c);
-      DataStream& operator >>(long& c);
-      DataStream& operator >>(unsigned long& c);
+      DataStream& operator >>(long long& c);
+      DataStream& operator >>(unsigned long long& c);
       DataStream& operator >>(unsigned short& c);
       DataStream& operator >>(short& c);
 

--- a/src/utils/DataStream.h
+++ b/src/utils/DataStream.h
@@ -18,6 +18,7 @@
 #include <utils/Endian.h>           // for enum
 #include <dis6/msLibMacro.h>       // for library symbols
 #include <cstdlib>                // for size_t and NULL definition
+#include <cstring>                // for memcpy
 
 namespace DIS
 {
@@ -116,7 +117,7 @@ namespace DIS
          char ch[sizeof(T)];
          DoRead( ch , sizeof(T) );
          DoFlip( ch , sizeof(T) );
-         t = *reinterpret_cast<T*>( ch );
+         memcpy(&t, ch, sizeof(t));
          IncrementPointer<T>( _read_pos );
       }
 

--- a/src/utils/PDUBank.cpp
+++ b/src/utils/PDUBank.cpp
@@ -71,10 +71,8 @@ Pdu* PduBank::GetStaticPDU( DIS::PDUType pdu_type )
       case PDU_EVENT_REPORT:      return &eventReportPdu;      break; 
       case PDU_COMMENT:           return &commentPdu;          break; 
       case PDU_STOP_FREEZE:       return &stopFreezePdu;       break;
-      default:                    return NULL;
+      default:                                                 break;
    }
-   // Code should never reach here because of the default case,
-   // but leaving here - just in case 0.0
    return NULL;
 }
 

--- a/src/utils/PDUBank.cpp
+++ b/src/utils/PDUBank.cpp
@@ -71,8 +71,10 @@ Pdu* PduBank::GetStaticPDU( DIS::PDUType pdu_type )
       case PDU_EVENT_REPORT:      return &eventReportPdu;      break; 
       case PDU_COMMENT:           return &commentPdu;          break; 
       case PDU_STOP_FREEZE:       return &stopFreezePdu;       break;
+      default:                    return NULL;
    }
-
+   // Code should never reach here because of the default case,
+   // but leaving here - just in case 0.0
    return NULL;
 }
 


### PR DESCRIPTION
This pull request addresses compiler warnings discussed in issue #29, and the pull request #30.
The warnings were predominately caused by the use of `char` instead of `unsigned char`, and `int` instead `unsigned long` (int).

While making these changes, I compared at the sizes of `char`, `int`, `long`, and `long long`, using two different compilers (GCC, and MSVC) and found that `long` varied between 32 bits and 64 bits depending on the compiler. Because of this discrepancy I replaced all `long`s with `long long`s, and checked against the DIS standard to confirm altered attributes required 64 bit integers. 
These check in turn resulted in some minor corrections of the DIS7 `AttachedParts`, & `ArticulatedParts` Classes; and I think the `Attribute` class still needs corrections that I'll raise an issue for.

Additionally, it adds a build target entry for OpenDIS7 to the premake5 file, and addresses issues #6, to create a successful compile of the DIS 7 code.