### PR TITLE
Add mechanism to register custom PDU banks

### DIFF
--- a/src/utils/IPduBank.h
+++ b/src/utils/IPduBank.h
@@ -1,0 +1,24 @@
+#ifndef _IPDU_BANK_H_
+#define _IPDU_BANK_H_
+
+#include <dis6/Pdu.h>
+#include <utils/DataStream.h>
+
+namespace DIS
+{
+    /// houses instances for the set of known PDU classes to be returned
+    /// when provided with the PDU type's identifier value.
+    class IPduBank
+    {
+    public:
+        ~IPduBank(){}
+
+        /// finds the PDU instance corresponding to the identifier
+        /// @param pdu_type the 8-bit PDU type identifier
+        /// @return NULL when the pdu_type is unknown.
+        virtual Pdu* GetStaticPDU( unsigned char pdu_type, DataStream& ds ) = 0;  
+    };   
+}
+
+#endif // _IPDU_BANK_H_
+

--- a/src/utils/IncomingMessage.h
+++ b/src/utils/IncomingMessage.h
@@ -6,9 +6,11 @@
 #define _dcl_dis_incoming_message_
 
 #include <utils/IBufferProcessor.h>   // for base class
+#include <utils/IPduBank.h> 
 #include <map>                      // for member
 #include <utils/Endian.h>             // for internal type
 #include <dis6/msLibMacro.h>         // for library symbols
+#include <utils/PDUType.h>
 
 namespace DIS
 {
@@ -22,6 +24,9 @@ namespace DIS
    public:
       /// the container type for supporting processors.
       typedef std::multimap<unsigned char,IPacketProcessor*> PacketProcessorContainer;
+      
+      /// the container type for supporting PDU banks.
+      typedef std::multimap<unsigned char,IPduBank*> PduBankContainer;
 
       IncomingMessage();
       ~IncomingMessage();
@@ -36,18 +41,34 @@ namespace DIS
       /// @return 'true' if the pair of parameters were found in the container and removed.  'false' if the pair was not found.
       bool RemoveProcessor(unsigned char id, const IPacketProcessor* pp);
 
+      /// registers the PDU bank instance to provide the PDU object
+      /// @return 'true' if the pair of parameters were not found in the container and were addded.  'false' if the pair was found.
+      bool AddPduBank(unsigned char pdu_type, IPduBank* pduBank);
+
+      /// unregisters the PDU bank instance
+      /// @return 'true' if the pair of parameters were found in the container and removed.  'false' if the pair was not found.
+      bool RemovePduBank(unsigned char pdu_type, const IPduBank* pduBank);
+
       PacketProcessorContainer& GetProcessors();
       const PacketProcessorContainer& GetProcessors() const;
 
+      PduBankContainer& GetPduBanks();
+      const PduBankContainer& GetPduBanks() const;
+
    private:
       typedef std::pair<PacketProcessorContainer::iterator, PacketProcessorContainer::iterator> PacketProcessIteratorPair;
-
       PacketProcessorContainer _processors;
+      
+      typedef std::pair<PduBankContainer::iterator, PduBankContainer::iterator> PduBankIteratorPair;
+      PduBankContainer _pduBanks;
 
-      void SwitchOnType(unsigned char pdu_type, DataStream& ds);
+      void SwitchOnType(DIS::PDUType pdu_type, DataStream& ds);
 
       /// Searches the proccesor container multimap for a matching container and returns the iterator
       bool FindProccessorContainer(unsigned char id, const IPacketProcessor* pp, PacketProcessorContainer::iterator &containerIter);
+
+      /// Searches the PDU bank container multimap for a matching container and returns the iterator
+      bool FindPduBankContainer(unsigned char pdu_type, const IPduBank* pduBank, PduBankContainer::iterator &containerIter);
    };
 
 }


### PR DESCRIPTION
Use a similar mechanism to the packet processors to register custom PDU banks. This allows to add new DIS PDUs or a different PDU bank implementation. By default (i.e. if no PDU bank is registered), the open-dis-cpp `PDUBank` is used.

Usage:
- Derive from `IPduBank`
- Register via `IncomingMessage::AddPduBank`