### PR TITLE
CMake Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ Makefile
 obj/
 Build/
 build/
+CMakeCache.txt
+*.dir/
+CMakeFiles
+cmake_install.cmake
+CPackConfig.cmake
+CPackSourceConfig.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Makefile
 *.suo
 obj/
 Build/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,25 @@
 language: cpp
 
+addons:
+  apt:
+    packages:
+      - cmake 
+      - libsdl2-dev
+      - libsdl2-net-dev
+      - rpm
+
 install:
-  # Download and build premake5 from source; the Travis environment doesn't have the right version of glibc6 for the prebuilt binaries to work.
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha6/premake-5.0.0-alpha6-src.zip -O premake.zip
-  - unzip premake.zip
-  - cd premake-5.0.0-alpha6/build/gmake.unix
-  - make config=release
-  - cd ../../..
-  - mv premake-5.0.0-alpha6/bin/release/premake5 premake5
-  # Download and build both SDL2 from source
-  - wget http://libsdl.org/release/SDL2-2.0.9.tar.gz
-  - tar -xvf SDL2-2.0.9.tar.gz
-  - pushd SDL2-2.0.9/
-  - ./configure --prefix=/usr && make && sudo make install
-  - popd
-  # Run sdl2-config for debugging -- protentially remove this
-  - sdl2-config --cflags --libs
-  # Download and build both SDL2_net from source
-  - wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz
-  - tar -xvf SDL2_net-2.0.1.tar.gz
-  - pushd SDL2_net-2.0.1/
-  - ./configure --prefix=/usr && make && sudo make install
-  - popd
 
 
 # Run premake to generate makefiles.
 before_script:
-  - ./premake5 gmake
+  - mkdir build
+  - pushd build
+  - cmake .. -DCMAKE_INSTALL_PREFIX=./install
+  - popd
 
 script:
-  - make config=release
+  - pushd build
+  - make install
+  - make package
+  - popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,25 +2,41 @@ cmake_minimum_required(VERSION 3.2)
 project(OpenDIS)
 
 ## Libraries
+
+# Add src/ to the include directories
 include_directories(src)
 
+# create list of DIS6 source files
 file(GLOB DIS6_SOURCES
   "src/dis6/*.cpp"
   "src/utils/*.cpp"
 )
+# Define ExampleSender Executable
 add_library(OpenDIS6 SHARED ${DIS6_SOURCES})
+# Add compile definition EXPORT_LIBRARY for DIS6 msLibMacro.h
+target_compile_definitions(OpenDIS6 PRIVATE EXPORT_LIBRARY)
 
+# create list of DIS7 source files
 file(GLOB DIS7_SOURCES
   "src/dis7/*.cpp"
   "src/utils/*.cpp"
 )
+# Define ExampleSender Executable
 add_library(OpenDIS7 SHARED ${DIS7_SOURCES})
+# Add compile definition EXPORT_LIBRARY for DIS7 msLibMacro.h
+target_compile_definitions(OpenDIS7 PRIVATE EXPORT_LIBRARY)
 
 
 ## Example Programs
 include_directories(.)
-set(LIB_FLAGS "-lSDL2 -lSDL2_net")
 
+# if Windows add M_PI definition
+# - issues occurred during testing in Visual Studio
+if (WIN32)
+  add_definitions(/DM_PI=3.14159265358979323846)
+endif (WIN32)
+
+# create list of ExampleSender source files
 file(GLOB EX_SENDER_SOURCES
   "examples/main.cpp"
   "examples/Connection.cpp"
@@ -28,10 +44,13 @@ file(GLOB EX_SENDER_SOURCES
   "examples/Timer.cpp"
 )
 
+# Define ExampleSender Executable
 add_executable(ExampleSender ${EX_SENDER_SOURCES})
-target_link_libraries(ExampleSender ${LIB_FLAGS})
-target_link_libraries(ExampleSender OpenDIS6)
+# Link OpenDIS into ExampleSender
+target_link_libraries(ExampleSender PRIVATE OpenDIS6)
+target_link_libraries(ExampleSender PRIVATE SDL2main SDL2 SDL2_net)
 
+# create list of ExampleReceiver source files
 file(GLOB EX_RECEIVER_SOURCES
   "examples/main_receive.cpp"
   "examples/Connection.cpp"
@@ -40,16 +59,95 @@ file(GLOB EX_RECEIVER_SOURCES
   "examples/EntityStatePduProcessor.cpp"
 )
 
+# Define ExampleReciever Executable
 add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
-target_link_libraries(ExampleReceiver ${LIB_FLAGS})
-target_link_libraries(ExampleReceiver OpenDIS6)
+# Link OpenDIS into ExampleReceiver
+target_link_libraries(ExampleReceiver PRIVATE OpenDIS6)
+target_link_libraries(ExampleReceiver PRIVATE SDL2main SDL2 SDL2_net)
 
+# Configuring SDL2
+#--------------------------------------------------------------------------------------
+
+# If SDL_INC_DIR declared (by user via -D flag)
+if(SDL_INC_DIR)
+  # Inform the user we will use the their specified SDL_INC_DIR
+  message("Using SDL2 include directory defined with -DSDL_INC_DIR")
+  message("\tvalue: ${SDL_INC_DIR}")
+  # Add SDL_INC_DIR to the include directories for both exampe apps
+  target_include_directories(ExampleSender PUBLIC ${SDL_INC_DIR})
+  target_include_directories(ExampleReceiver PUBLIC ${SDL_INC_DIR})
+else(SDL_INC_DIR)
+  # Otherwise, try get SDL2 Compiler Flags from sdl2-config
+  execute_process(
+    COMMAND sdl2-config --cflags
+    RESULT_VARIABLE SDL_CERR
+    OUTPUT_VARIABLE SDL_CFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # if sdl2-config errors
+  if(SDL_CERR)
+    # warn user that they may have to define the SDL2 include
+    #  directory with the -DSDL_INC_DIR flag
+    # Most linux systems will probably be fine
+    message(WARNING "Unable to detect SDL2 include flags")
+    message("You may need to specify the SDL include manually")
+    message(" with -DSDL_INC_DIR=<SDL2 include path>")
+  else(SDL_CERR)
+    # otherwise split the output of sdl2-config and add to compiler flags to examples
+    if(WIN32)
+      separate_arguments(SDL_CFLAGS UNIX_COMMAND "${SDL_CFLAGS}")
+    else(WIN32)
+      separate_arguments(SDL_CFLAGS WINDOWS_COMMAND "${SDL_CFLAGS}")
+    endif(WIN32)
+    target_compile_options(ExampleSender PRIVATE "${SDL_CFLAGS}")
+    target_compile_options(ExampleReceiver PRIVATE "${SDL_CFLAGS}")
+  endif(SDL_CERR)
+endif(SDL_INC_DIR)
+
+# If SDL_LIB_DIR declared (by user via -D flag)
+if(SDL_LIB_DIR)
+  message("Using SDL2 include directory defined with -DSDL_LIB_DIR")
+  message("\tvalue: ${SDL_LIB_DIR}")
+  target_link_directories(ExampleSender PUBLIC ${SDL_LIB_DIR})
+  target_link_directories(ExampleReceiver PUBLIC ${SDL_LIB_DIR})
+else(SDL_LIB_DIR)
+  # Otherwise, try get SDL2 Library Flags from sdl2-config
+  execute_process(
+    COMMAND sdl2-config --libs
+    RESULT_VARIABLE SDL_LERR
+    OUTPUT_VARIABLE SDL_LFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # if sdl2-config errors
+  if(SDL_LERR)
+    # warn user that they may have to define the SDL2 include
+    #  directory with the -DSDL_LIB_DIR flag
+    # Most linux systems will probably be fine
+    message(WARNING "Unable to detect SDL2 library flags using defaults")
+    message("You may need to specify the SDL library manually with")
+    message(" -DSDL_LIB_DIR=<SDL2 include path>, especially for Windows users")
+  else(SDL_LERR)
+    # otherwise split the output of sdl2-config and add to library flags to examples
+    if(WIN32)
+      separate_arguments(SDL_LFLAGS UNIX_COMMAND "${SDL_LFLAGS}")
+    else(WIN32)
+      separate_arguments(SDL_LFLAGS WINDOWS_COMMAND "${SDL_LFLAGS}")
+    endif(WIN32)
+    target_link_libraries(ExampleSender PRIVATE "${SDL_LFLAGS}")
+    target_link_libraries(ExampleReceiver PRIVATE "${SDL_LFLAGS}")
+  endif(SDL_LERR)
+endif(SDL_LIB_DIR)
+
+#--------------------------------------------------------------------------------------
+
+# Configure install target (i.e. what files to install)
 install(TARGETS OpenDIS6 OpenDIS7 DESTINATION "lib")
 install(TARGETS ExampleReceiver ExampleSender DESTINATION "bin")
 install(DIRECTORY src/ DESTINATION "include"
         FILES_MATCHING PATTERN "*.h"
 )
 
+# configure package target (i.e. Package Types, and meta data)
 set(CPACK_GENERATOR "DEB" "RPM" "TXZ" "TGZ")
 set(CPACK_PACKAGE_VERSION 1.0.0)
 set(CPACK_PACKAGE_NAME "OpenDis")
@@ -59,5 +157,4 @@ set(CPACK_PACKAGE_RPM_DIR "${CMAKE_CURRENT_BINARY_DIR}/_CPack_Packages/Linux/RPM
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Leif Gruenwoldt <leifer@gmail.com>")
 set(CPACK_PACKAGE_PACKAGER $ENV{USER})
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The open DIS cpp library")
-
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,3 +43,9 @@ file(GLOB EX_RECEIVER_SOURCES
 add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
 target_link_libraries(ExampleReceiver ${LIB_FLAGS})
 target_link_libraries(ExampleReceiver OpenDIS6)
+
+install(TARGETS OpenDIS6 OpenDIS7 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS ExampleReceiver ExampleSender DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+        FILES_MATCHING PATTERN "*.h"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,20 @@ add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
 target_link_libraries(ExampleReceiver ${LIB_FLAGS})
 target_link_libraries(ExampleReceiver OpenDIS6)
 
-install(TARGETS OpenDIS6 OpenDIS7 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(TARGETS ExampleReceiver ExampleSender DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-install(DIRECTORY src/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+install(TARGETS OpenDIS6 OpenDIS7 DESTINATION "lib")
+install(TARGETS ExampleReceiver ExampleSender DESTINATION "bin")
+install(DIRECTORY src/ DESTINATION "include"
         FILES_MATCHING PATTERN "*.h"
 )
+
+set(CPACK_GENERATOR "DEB" "RPM" "TXZ" "TGZ")
+set(CPACK_PACKAGE_VERSION 1.0.0)
+set(CPACK_PACKAGE_NAME "OpenDis")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The open DIS cpp library")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}.${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_PACKAGE_RPM_DIR "${CMAKE_CURRENT_BINARY_DIR}/_CPack_Packages/Linux/RPM")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Leif Gruenwoldt <leifer@gmail.com>")
+set(CPACK_PACKAGE_PACKAGER $ENV{USER})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The open DIS cpp library")
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.2)
+project(OpenDIS)
+
+## Libraries
+include_directories(src)
+
+file(GLOB DIS6_SOURCES
+  "src/dis6/*.cpp"
+  "src/utils/*.cpp"
+)
+add_library(OpenDIS6 SHARED ${DIS6_SOURCES})
+
+file(GLOB DIS7_SOURCES
+  "src/dis7/*.cpp"
+  "src/utils/*.cpp"
+)
+add_library(OpenDIS7 SHARED ${DIS7_SOURCES})
+
+
+## Example Programs
+include_directories(.)
+set(LIB_FLAGS "-lSDL2 -lSDL2_net")
+
+file(GLOB EX_SENDER_SOURCES
+  "examples/main.cpp"
+  "examples/Connection.cpp"
+  "examples/Utils.cpp"
+  "examples/Timer.cpp"
+)
+
+add_executable(ExampleSender ${EX_SENDER_SOURCES})
+target_link_libraries(ExampleSender ${LIB_FLAGS})
+target_link_libraries(ExampleSender OpenDIS6)
+
+file(GLOB EX_RECEIVER_SOURCES
+  "examples/main_receive.cpp"
+  "examples/Connection.cpp"
+  "examples/Utils.cpp"
+  "examples/Timer.cpp"
+  "examples/EntityStatePduProcessor.cpp"
+)
+
+add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
+target_link_libraries(ExampleReceiver ${LIB_FLAGS})
+target_link_libraries(ExampleReceiver OpenDIS6)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
   It can be downloaded and installed from http://cmake.org/
 
 * SDL2 and SDL2_net are required libraries to compile the examples.
-  These can usually be install via linux package managers.
+  These can usually be install via Linux package managers.
   More details, and instructions for Windows are included [below](#SDL2-and-SDL2_net-Install-Instructions).
-**NOTE:** Windows users will need to either add the DLL folders to their path, or copy the DLLs to the output directory (`Debug`).
+
+  **NOTE:** Windows users will need to either add the DLL folders to their path, or copy the DLLs to the output directory (`Debug`).
 
 ### Linux / GNU Makefiles
 
@@ -23,13 +24,41 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
   1. Optionally, `-DCMAKE_INSTALL_PREFIX=<custom-path-to-install>` to set a custom directory to install the bin, include, and lib output directories.
 1. Run `make` - this will output the libOpenDIS6.so, and libOpenDIS7.so libraries in the build directory along with the Example Applications.
 1. The below steps are optional
-  1. Run `make package` to build linux package files. Currently this will produce a RedHat RPM package, Debian DEB package, and 2 compressed tarball (XZ, GZ).
+  1. Run `make package` to build Linux package files. Currently this will produce a Red Hat RPM package, Debian DEB package, and 2 compressed tarball (XZ, GZ).
   1. Run `make install` to install bin, lib, and dir, into `CMAKE_INSTALL_PREFIX`
      WARNING: `CMAKE_INSTALL_PREFIX` default can to somewhere `/usr/local/`, if not specified with the `-D` flag as shown in Step 3.1.
      If you're unsure where to install, and want to keep your `/usr/local/` directory clean, run `cmake .. -DCMAKE_INSTALL_PREFIX=./install`.
      This will cause `make install` to create a local install directory, from which you can move files elsewhere at a later date.
 
+#### Windows with Visual Studio
+1. Open `CMake (cmake-gui)` via the the start menu.
+2. Enter the open-dis-cpp directory path into the Source and Build fields.
+3. Click the `+ Add Entry` button and enter the following details:
+  Name: `SDL_INC_DIR`
+  Type: `PATH`
+  Value: `<SDL2-install-folder>/include`
+  (if you follow the below [SDL2 Windows Install Instruction](#Windows-Install-Instructions) this will be `C:/SDL2/include`)
+3. Click the `+ Add Entry` button and enter the following details:
+  Name: `SDL_LIB_DIR`
+  Type: `PATH`
+  Value: `<SDL2-install-folder>/lib/x64` (64 bit) or `<SDL2-install-folder>/lib/x86` (32 bit)
+  (if you follow the below [SDL2 Windows Install Instruction](#Windows-Install-Instructions) this will be `C:/SDL2/lib/x64`)
+4. Click Configure and follow the prompts, selecting the correct generator (i.e. Visual Studio version).
+5. Click Generate
+6. Click Open Project - This should open the generates solution file in Visual Studio
+7. Build the Solution (`Ctrl + Shift + B`)
 
+These steps were tested with Visual Studio 16 2019 (Community Edition).
+Currently, only OpenDIS 6 and the Example Applications compile.
+The library and executable files are output to a `Debug` directory.
+
+To run the executables, either the value of the `SDL_LIB_DIR` variable should be added to your path,
+or `SDL2.dll` and `SDL2_net.dll` need to be copied to the `Debug` directory.
+
+### Cleaning CMake files
+
+To quickly clean up CMake output files, use `git clean -xdf`.
+**Note:** Use with care if you are actually developing open-dis-cpp, as `git clean` removes untracked files.
 
 ### Old Pre-make build instructions
 
@@ -60,7 +89,7 @@ Ubuntu: ```sudo apt-get install libsdl2-dev libsdl2-net-dev```
 
 If you're unable to install the correct packages, try [installing from source](#POSIX-Source-Installation)
 
-### Windows Instructions
+### Windows Install Instructions
 
 These are the installation steps that have been tested with open-dis-cpp, however there are other methods for installation.
 Experienced users should feel free to customise their install.
@@ -90,8 +119,11 @@ Experienced users should feel free to customise their install.
 #### (Core) SDL2
 Run the following commands:
 1. `wget http://libsdl.org/release/SDL2-2.0.12.tar.gz`
+
    Or, Download via your favourite web browser.
+
    **NOTE:** check the [download](https://www.libsdl.org/download-2.0.php) page for new releases
+
 2. `tar -xvf SDL2-2.0.9.tar.gz`
 3. `pushd SDL2-2.0.9/`
 4. `./configure --prefix=/usr && make && sudo make install`
@@ -99,8 +131,11 @@ Run the following commands:
 
 #### SDL2_net
 1. `wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz`
+
    Or, Download via your favourite web browser.
+
    **NOTE:** check [https://www.libsdl.org/projects/SDL_net](project) page for new releases
+
 2. `tar -xvf SDL2_net-2.0.1.tar.gz`
 3. `pushd SDL2_net-2.0.1/`
 4. `./configure --prefix=/usr && make && sudo make install`

--- a/README.md
+++ b/README.md
@@ -11,13 +11,29 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
 
 * SDL2 and SDL2_net are required libraries to compile the examples. See the [.travis.yml](.travis.yml) for more details on setting up a build environment.
 
-### Linux
+### Linux / GNU Makefiles
 
+1. Run `mkdir build`
+1. Run `cd build`
+1. Run `cmake ..`
+  1. Optionally, `-DCMAKE_INSTALL_PREFIX=<custom-path-to-install>` to set a custom directory to install the bin, include, and lib output directories.
+1. Run `make` - this will output the libOpenDIS6.so, and libOpenDIS7.so libraries in the build directory along with the Example Applications.
+1. The below steps are optional
+  1. Run `make package` to build linux package files. Currently this will produce a RedHat RPM package, Debian DEB package, and 2 compressed tarball (XZ, GZ).
+  1. Run `make install` to install bin, lib, and dir, into `CMAKE_INSTALL_PREFIX`
+     WARNING: `CMAKE_INSTALL_PREFIX` default can to somewhere `/usr/local/`, if not specified with the `-D` flag as shown in Step 3.1.
+     If you're unsure where to install, and want to keep your `/usr/local/` directory clean, run `cmake .. -DCMAKE_INSTALL_PREFIX=./install`.
+     This will cause `make install` to create a local install directory, from which you can move files elsewhere at a later date.
+
+
+
+### Old Pre-make build instructions
+#### Linux / GNU Makefiles
 1. Run `premake5 gmake`
 1. Run `make config=release`
 
-### Windows
 
+#### Windows with Visual Studio 2015
 1. Run `premake5 vs2015`
 1. Open the solution and build.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
 
 ## Building Open DIS
 
-* [premake5](http://premake.github.io/) is required to build the platform specific projects. Download it and make sure it's available on your path, or specify the path to it. 
+* [CMake](http://cmake.org/) is required to build the platform specific projects.
+  It can be downloaded and installed from http://cmake.org/
 
-* SDL2 and SDL2_net are required libraries to compile the examples. See the [.travis.yml](.travis.yml) for more details on setting up a build environment.
+* SDL2 and SDL2_net are required libraries to compile the examples.
+  These can usually be install via linux package managers.
+  More details, and instructions for Windows are included [below](#SDL2-and-SDL2_net-Install-Instructions).
+**NOTE:** Windows users will need to either add the DLL folders to their path, or copy the DLLs to the output directory (`Debug`).
 
 ### Linux / GNU Makefiles
 
@@ -28,6 +32,9 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
 
 
 ### Old Pre-make build instructions
+
+* [premake5](http://premake.github.io/) is required to build the platform specific projects. Download it and make sure it's available on your path, or specify the path to it.
+
 #### Linux / GNU Makefiles
 1. Run `premake5 gmake`
 1. Run `make config=release`
@@ -40,3 +47,61 @@ Initially generated with [xmlpg](https://github.com/open-dis/xmlpg).
 ## Developer Docs
 
 The latest doxygen docs for the Open DIS master branch can be found [here](https://codedocs.xyz/open-dis/open-dis-cpp/).
+
+## SDL2 and SDL2_net Install Instructions
+
+### Linux Package Managers
+
+Arch: ```sudo pacman -S sdl2 sdl2_net```
+
+Fedora: ```sudo dnf install SDL2-devel SDL2_net-devel```
+
+Ubuntu: ```sudo apt-get install libsdl2-dev libsdl2-net-dev```
+
+If you're unable to install the correct packages, try [installing from source](#POSIX-Source-Installation)
+
+### Windows Instructions
+
+These are the installation steps that have been tested with open-dis-cpp, however there are other methods for installation.
+Experienced users should feel free to customise their install.
+
+#### (Core) SDL2 Instructions
+
+1. Navigate to the SDL2 [Download](https://www.libsdl.org/download-2.0.php) page, and download the latest Development Libraries.
+
+   Alternatively, the version tested with open-dis-cpp, 2.0.12-VC, can be downloaded from this [direct link](https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip).
+
+2. Extract the SDL2-devel-2.0.12-VC.zip file directly to your `C:\`.
+3. Rename the resulting `SDL2-2.0.12` folder to `SDL2`.
+4. Add `C:\SDL2\lib\x64` to your System Path for 64-bit systems,
+   or add `C:\SDL2\lib\x86` for 32-bit systems.
+
+#### SDL2_net Instructions
+
+1. Navigate to the SDL2_net [project](https://www.libsdl.org/projects/SDL_net/) page, and download the latest Development Libraries.
+
+   Alternatively, the version tested with open-dis-cpp, 2.0.1-VC, can be downloaded from this [direct link](https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-VC.zip).
+
+2. Extract the SDL2-devel-2.0.12-VC.zip
+3. Copy the `include` and `lib` directories from the resulting folder into you `C:\SDL2\` folder
+
+### POSIX Source Installation
+
+#### (Core) SDL2
+Run the following commands:
+1. `wget http://libsdl.org/release/SDL2-2.0.12.tar.gz`
+   Or, Download via your favourite web browser.
+   **NOTE:** check the [download](https://www.libsdl.org/download-2.0.php) page for new releases
+2. `tar -xvf SDL2-2.0.9.tar.gz`
+3. `pushd SDL2-2.0.9/`
+4. `./configure --prefix=/usr && make && sudo make install`
+5. `popd`
+
+#### SDL2_net
+1. `wget https://www.libsdl.org/projects/SDL_net/release/SDL2_net-2.0.1.tar.gz`
+   Or, Download via your favourite web browser.
+   **NOTE:** check [https://www.libsdl.org/projects/SDL_net](project) page for new releases
+2. `tar -xvf SDL2_net-2.0.1.tar.gz`
+3. `pushd SDL2_net-2.0.1/`
+4. `./configure --prefix=/usr && make && sudo make install`
+5. `popd`

--- a/examples/Connection.cpp
+++ b/examples/Connection.cpp
@@ -4,8 +4,8 @@
 #include <sstream>
 #include <cstring>
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_net.h>
+#include <SDL.h>
+#include <SDL_net.h>
 
 using namespace Example;
 

--- a/examples/Connection.h
+++ b/examples/Connection.h
@@ -4,8 +4,8 @@
 #include <string>                        // for param
 #include <cstddef>                       // for size_t definition
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_net.h>
+#include <SDL.h>
+#include <SDL_net.h>
 
 
 namespace Example

--- a/examples/Readme.txt
+++ b/examples/Readme.txt
@@ -11,18 +11,8 @@ library. Please visit https://www.libsdl.org/ for information about how to
 SDL2 also provides timing functionality. I.e. calculating delta between frames
 and for sleep delays.
 
-The current `#include` are written with the prefix "SDL2/" because the
-contributor was unfamiliar with premake5.
-Normally it is recommended to add the output of `sdl2-config --cflags` and
-`sdl2-config --libs` to the build process, however it was unclear if this
-work across different systems.
-
 Build instructions:
-1. cd to the repo root
-2. run `premake5 gmake` (If not done already)
-3. run `make`
-Files will be located in ./Build/lib/Debug
+See project README.md, in repo root directory.
+
 Running instructions: 
-1. open up 2 terminals in the git repo root:
-2. Run `./Build/lib/Debug/ExampleReceiver` in one terminal
-3. Run `./Build/lib/Debug/ExampleSender` in the other terminal
+Run `ExampleReceiver` and `ExampleSender` in seperate terminals

--- a/examples/Timer.cpp
+++ b/examples/Timer.cpp
@@ -5,8 +5,8 @@
 
 #include <sstream>
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_timer.h>
+#include <SDL.h>
+#include <SDL_timer.h>
 
 using namespace Example;
 

--- a/examples/Timer.h
+++ b/examples/Timer.h
@@ -1,8 +1,8 @@
 #ifndef _example_timer_h_
 #define _example_timer_h_
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_timer.h>
+#include <SDL.h>
+#include <SDL_timer.h>
 
 namespace Example
 {

--- a/examples/Utils.cpp
+++ b/examples/Utils.cpp
@@ -9,7 +9,7 @@
 #include <dis6/Orientation.h>
 #include <dis6/Vector3Float.h>
 #include <dis6/Vector3Double.h>
-#include <SDL2/SDL_timer.h>
+#include <SDL_timer.h>
 
 ///\todo make cross platform solution
 void Example::sleep(unsigned int ms)


### PR DESCRIPTION
This is my attempt at a CMake Build for Open DIS C++.

This CMake File (CMakeLists.txt):
- handles SDL2 across platforms
  - making it work on Windows really blew out the file size.
- Windows compile definitions
  - EXPORT_LIBRARY for msLibMacro.h
  - M_PI=3.14...
    - I feel like this shouldn't have been necessary but I couldn't get the example apps to compile without it
- Linux RPM & DEB Packaging 
   - currently package will fail if you don't have the relevant Debian and RPM packaging tools, although one can simply remove `"DEB"` and/or `"RPM"` where necessary and it should succeed. 
- has been tested on Arch Linux using GNU Make, and Windows using Visual Studio 16 2019

I tried to update the README to cover all the step, although I highly recommend someone else try following the instructions before the Pull Request is merged, to make sure they actually makes sense and does skip anything.

During the update I figured out how to Travis-CI to install dependencies with apt, rather than making them from scratch.