### PR TITLE
Appveyor plus cmake enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ CMakeFiles
 cmake_install.cmake
 CPackConfig.cmake
 CPackSourceConfig.cmake
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ before_script:
 
 script:
   - pushd build
-  - make install
+  - make -j install
   - make package
   - popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ project(OpenDIS)
 
 ## Libraries
 
-# Add src/ to the include directories
-include_directories(src)
 
 # create list of DIS6 source files
 file(GLOB DIS6_SOURCES
@@ -13,6 +11,8 @@ file(GLOB DIS6_SOURCES
 )
 # Define ExampleSender Executable
 add_library(OpenDIS6 SHARED ${DIS6_SOURCES})
+# Add src/ to the include directories to OpenDIS6
+target_include_directories(OpenDIS6 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> $<INSTALL_INTERFACE:> )
 # Add compile definition EXPORT_LIBRARY for DIS6 msLibMacro.h
 target_compile_definitions(OpenDIS6 PRIVATE EXPORT_LIBRARY)
 
@@ -23,6 +23,8 @@ file(GLOB DIS7_SOURCES
 )
 # Define ExampleSender Executable
 add_library(OpenDIS7 SHARED ${DIS7_SOURCES})
+# Add src/ to the include directories to OpenDIS6
+target_include_directories(OpenDIS7 PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> $<INSTALL_INTERFACE:> )
 # Add compile definition EXPORT_LIBRARY for DIS7 msLibMacro.h
 target_compile_definitions(OpenDIS7 PRIVATE EXPORT_LIBRARY)
 
@@ -44,11 +46,19 @@ file(GLOB EX_SENDER_SOURCES
   "examples/Timer.cpp"
 )
 
+if(WIN32)
+       set(SDL_LIBS SDL2main SDL2 SDL2_net)
+else(WIN32)
+       set(SDL_LIBS SDL2 SDL2_net)
+endif(WIN32)
+
 # Define ExampleSender Executable
 add_executable(ExampleSender ${EX_SENDER_SOURCES})
 # Link OpenDIS into ExampleSender
 target_link_libraries(ExampleSender PRIVATE OpenDIS6)
-target_link_libraries(ExampleSender PRIVATE SDL2main SDL2 SDL2_net)
+target_link_libraries(ExampleSender PRIVATE ${SDL_LIBS})
+# add src to ExampleSender include directories
+target_include_directories(ExampleSender PRIVATE src)
 
 # create list of ExampleReceiver source files
 file(GLOB EX_RECEIVER_SOURCES
@@ -59,11 +69,13 @@ file(GLOB EX_RECEIVER_SOURCES
   "examples/EntityStatePduProcessor.cpp"
 )
 
-# Define ExampleReciever Executable
+# Define ExampleReceiver Executable
 add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
 # Link OpenDIS into ExampleReceiver
 target_link_libraries(ExampleReceiver PRIVATE OpenDIS6)
-target_link_libraries(ExampleReceiver PRIVATE SDL2main SDL2 SDL2_net)
+target_link_libraries(ExampleReceiver PRIVATE ${SDL_LIBS})
+# add src to ExampleSender include directories
+target_include_directories(ExampleReceiver PRIVATE src)
 
 # Configuring SDL2
 #--------------------------------------------------------------------------------------
@@ -140,8 +152,13 @@ endif(SDL_LIB_DIR)
 
 #--------------------------------------------------------------------------------------
 
+# include GNUInstallDirs Module to get more generic directory handling
+include(GNUInstallDirs)
 # Configure install target (i.e. what files to install)
-install(TARGETS OpenDIS6 OpenDIS7 DESTINATION "lib")
+install(TARGETS OpenDIS6 EXPORT OpenDIS6Config DESTINATION "${LIBDIR}")
+install(EXPORT OpenDIS6Config DESTINATION "lib/cmake/OpenDIS6")
+install(TARGETS OpenDIS7 EXPORT OpenDIS7Config DESTINATION "${LIBDIR}")
+install(EXPORT OpenDIS7Config DESTINATION "lib/cmake/OpenDIS7")
 install(TARGETS ExampleReceiver ExampleSender DESTINATION "bin")
 install(DIRECTORY src/ DESTINATION "include"
         FILES_MATCHING PATTERN "*.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_compile_definitions(OpenDIS6 PRIVATE EXPORT_LIBRARY)
 # create list of DIS7 source files
 file(GLOB DIS7_SOURCES
   "src/dis7/*.cpp"
-  "src/utils/*.cpp"
+  "src/utils/DataStream.cpp"
 )
 # Define ExampleSender Executable
 add_library(OpenDIS7 SHARED ${DIS7_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ endif(SDL_LIB_DIR)
 
 # include GNUInstallDirs Module to get more generic directory handling
 include(GNUInstallDirs)
+IF(NOT DEFINED LIBDIR)
+  set(LIBDIR "lib")   # Was not defined on Travis CI
+ENDIF(NOT DEFINED LIBDIR)
 # Configure install target (i.e. what files to install)
 install(TARGETS OpenDIS6 EXPORT OpenDIS6Config DESTINATION "${LIBDIR}")
 install(EXPORT OpenDIS6Config DESTINATION "lib/cmake/OpenDIS6")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+image:
+  - Visual Studio 2019
+
+install: 
+  - curl -o C:\SDL2.zip https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip
+  - curl -o C:\SDL2_net.zip https://www.libsdl.org/projects/SDL_net/release/SDL2_net-devel-2.0.1-VC.zip
+  - 7z x C:\SDL2.zip -oC:\ -y
+  - move C:\SDL2-2.0.12 C:\SDL2
+  - 7z x C:\SDL2_net.zip -oC:\ -y  
+  - move C:\SDL2_net-2.0.1 C:\SDL2_net
+  - xcopy /s C:\SDL2_net\lib C:\SDL2\lib
+  - xcopy /s C:\SDL2_net\include C:\SDL2\include
+  - dir /s C:\SDL2
+
+platform: x64
+
+build:
+  project: OpenDIS.sln
+
+before_build:
+  - cmake -DSDL_LIB_DIR=C:\SDL2\lib\x64 -DSDL_INC_DIR=C:\SDL2\include .
+  - dir

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,128 @@
+cmake_minimum_required(VERSION 3.2)
+project(OpenDIS-Examples)
+
+## Libraries
+
+find_package(OpenDIS6)
+
+## Example Programs
+include_directories(.)
+
+# if Windows add M_PI definition
+# - issues occurred during testing in Visual Studio
+if (WIN32)
+  add_definitions(/DM_PI=3.14159265358979323846)
+endif (WIN32)
+
+# create list of ExampleSender source files
+file(GLOB EX_SENDER_SOURCES
+  "main.cpp"
+  "Connection.cpp"
+  "Utils.cpp"
+  "Timer.cpp"
+)
+
+if(WIN32)
+       set(SDL_LIBS SDL2main SDL2 SDL2_net)
+else(WIN32)
+       set(SDL_LIBS SDL2 SDL2_net)
+endif(WIN32)
+
+# Define ExampleSender Executable
+add_executable(ExampleSender ${EX_SENDER_SOURCES})
+# Link OpenDIS into ExampleSender
+target_link_libraries(ExampleSender PRIVATE OpenDIS6)
+target_link_libraries(ExampleSender PRIVATE ${SDL_LIBS})
+# add src to ExampleSender include directories
+target_include_directories(ExampleSender PRIVATE src)
+
+# create list of ExampleReceiver source files
+file(GLOB EX_RECEIVER_SOURCES
+  "main_receive.cpp"
+  "Connection.cpp"
+  "Utils.cpp"
+  "Timer.cpp"
+  "EntityStatePduProcessor.cpp"
+)
+
+# Define ExampleReceiver Executable
+add_executable(ExampleReceiver ${EX_RECEIVER_SOURCES})
+# Link OpenDIS into ExampleReceiver
+target_link_libraries(ExampleReceiver PRIVATE OpenDIS6)
+target_link_libraries(ExampleReceiver PRIVATE ${SDL_LIBS})
+# add src to ExampleSender include directories
+target_include_directories(ExampleReceiver PRIVATE src)
+
+# Configuring SDL2
+#--------------------------------------------------------------------------------------
+
+# If SDL_INC_DIR declared (by user via -D flag)
+if(SDL_INC_DIR)
+  # Inform the user we will use the their specified SDL_INC_DIR
+  message("Using SDL2 include directory defined with -DSDL_INC_DIR")
+  message("\tvalue: ${SDL_INC_DIR}")
+  # Add SDL_INC_DIR to the include directories for both exampe apps
+  target_include_directories(ExampleSender PUBLIC ${SDL_INC_DIR})
+  target_include_directories(ExampleReceiver PUBLIC ${SDL_INC_DIR})
+else(SDL_INC_DIR)
+  # Otherwise, try get SDL2 Compiler Flags from sdl2-config
+  execute_process(
+    COMMAND sdl2-config --cflags
+    RESULT_VARIABLE SDL_CERR
+    OUTPUT_VARIABLE SDL_CFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # if sdl2-config errors
+  if(SDL_CERR)
+    # warn user that they may have to define the SDL2 include
+    #  directory with the -DSDL_INC_DIR flag
+    # Most linux systems will probably be fine
+    message(WARNING "Unable to detect SDL2 include flags")
+    message("You may need to specify the SDL include manually")
+    message(" with -DSDL_INC_DIR=<SDL2 include path>")
+  else(SDL_CERR)
+    # otherwise split the output of sdl2-config and add to compiler flags to examples
+    if(WIN32)
+      separate_arguments(SDL_CFLAGS UNIX_COMMAND "${SDL_CFLAGS}")
+    else(WIN32)
+      separate_arguments(SDL_CFLAGS WINDOWS_COMMAND "${SDL_CFLAGS}")
+    endif(WIN32)
+    target_compile_options(ExampleSender PRIVATE "${SDL_CFLAGS}")
+    target_compile_options(ExampleReceiver PRIVATE "${SDL_CFLAGS}")
+  endif(SDL_CERR)
+endif(SDL_INC_DIR)
+
+# If SDL_LIB_DIR declared (by user via -D flag)
+if(SDL_LIB_DIR)
+  message("Using SDL2 include directory defined with -DSDL_LIB_DIR")
+  message("\tvalue: ${SDL_LIB_DIR}")
+  target_link_directories(ExampleSender PUBLIC ${SDL_LIB_DIR})
+  target_link_directories(ExampleReceiver PUBLIC ${SDL_LIB_DIR})
+else(SDL_LIB_DIR)
+  # Otherwise, try get SDL2 Library Flags from sdl2-config
+  execute_process(
+    COMMAND sdl2-config --libs
+    RESULT_VARIABLE SDL_LERR
+    OUTPUT_VARIABLE SDL_LFLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  # if sdl2-config errors
+  if(SDL_LERR)
+    # warn user that they may have to define the SDL2 include
+    #  directory with the -DSDL_LIB_DIR flag
+    # Most linux systems will probably be fine
+    message(WARNING "Unable to detect SDL2 library flags using defaults")
+    message("You may need to specify the SDL library manually with")
+    message(" -DSDL_LIB_DIR=<SDL2 include path>, especially for Windows users")
+  else(SDL_LERR)
+    # otherwise split the output of sdl2-config and add to library flags to examples
+    if(WIN32)
+      separate_arguments(SDL_LFLAGS UNIX_COMMAND "${SDL_LFLAGS}")
+    else(WIN32)
+      separate_arguments(SDL_LFLAGS WINDOWS_COMMAND "${SDL_LFLAGS}")
+    endif(WIN32)
+    target_link_libraries(ExampleSender PRIVATE "${SDL_LFLAGS}")
+    target_link_libraries(ExampleReceiver PRIVATE "${SDL_LFLAGS}")
+  endif(SDL_LERR)
+endif(SDL_LIB_DIR)
+

--- a/examples/Connection.cpp
+++ b/examples/Connection.cpp
@@ -1,5 +1,5 @@
-#include <examples/Connection.h>
-#include <examples/Logging.h>
+#include "Connection.h"
+#include "Logging.h"
 
 #include <sstream>
 #include <cstring>

--- a/examples/EntityStatePduProcessor.cpp
+++ b/examples/EntityStatePduProcessor.cpp
@@ -1,4 +1,4 @@
-#include <examples/EntityStatePduProcessor.h>
+#include "EntityStatePduProcessor.h"
 
 #include <iostream>
 

--- a/examples/Readme.txt
+++ b/examples/Readme.txt
@@ -12,7 +12,24 @@ SDL2 also provides timing functionality. I.e. calculating delta between frames
 and for sleep delays.
 
 Build instructions:
-See project README.md, in repo root directory.
+
+These executable are built within the main project build process, see the project
+README.md, in repo root directory.
+
+Additionally, these executables can be built using the `CMakeList.txt`
+file to test an OpenDIS installation.
+To do so, run the following commands in this directory:
+```
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make
+```
+If everything worked correctly, then OpenDIS is installed correctly.
+If you installed OpenDIS in a custom location you may have to add the flag
+`-DOpenDIS6_DIR=<path to OpenDIS install>/lib/cmake/OpenDIS6` to the cmake 
+command - this will apply to any other CMake projects you which to include
+OpenDIS6 in. (For OpenDIS7, just replace the 6s with 7s)
 
 Running instructions: 
 Run `ExampleReceiver` and `ExampleSender` in seperate terminals

--- a/examples/Timer.cpp
+++ b/examples/Timer.cpp
@@ -1,8 +1,8 @@
 
-#include <examples/Timer.h>
-#include <iostream>
+#include "Timer.h"
 #include "Logging.h"
 
+#include <iostream>
 #include <sstream>
 
 #include <SDL.h>

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,8 +1,8 @@
 
 // specific for the example
-#include <examples/Connection.h>
-#include <examples/Utils.h>
-#include <examples/Timer.h>
+#include "Connection.h"
+#include "Utils.h"
+#include "Timer.h"
 
 // the DIS library usage
 #include <dis6/EntityStatePdu.h>

--- a/examples/main_receive.cpp
+++ b/examples/main_receive.cpp
@@ -1,7 +1,7 @@
 
-#include <examples/Connection.h>                  // for reading packets from the socket
-#include <examples/EntityStatePduProcessor.h>     // for usage
-#include <examples/Utils.h>
+#include "Connection.h"                  // for reading packets from the socket
+#include "EntityStatePduProcessor.h"     // for usage
+#include "Utils.h"
 
 #include <utils/IncomingMessage.h>                 // for library usage
 #include <dis6/EntityStatePdu.h>                  // for library usage

--- a/src/dis6/DistributedEmissionsFamilyPdu.h
+++ b/src/dis6/DistributedEmissionsFamilyPdu.h
@@ -8,7 +8,7 @@
 
 namespace DIS
 {
-// Section 5.3.7. Electronic Emissions. Abstract superclass for distirubted emissions PDU
+// Section 5.3.7. Electromagnetic Emissions. Abstract superclass for distirubted emissions PDU
 
 // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
 //

--- a/src/dis6/ElectromagneticEmissionBeamData.cpp
+++ b/src/dis6/ElectromagneticEmissionBeamData.cpp
@@ -1,9 +1,9 @@
-#include <dis6/ElectronicEmissionBeamData.h>
+#include <dis6/ElectromagneticEmissionBeamData.h>
 
 using namespace DIS;
 
 
-ElectronicEmissionBeamData::ElectronicEmissionBeamData():
+ElectromagneticEmissionBeamData::ElectromagneticEmissionBeamData():
    _beamDataLength(0), 
    _beamIDNumber(0), 
    _beamParameterIndex(0), 
@@ -16,117 +16,117 @@ ElectronicEmissionBeamData::ElectronicEmissionBeamData():
 {
 }
 
-ElectronicEmissionBeamData::~ElectronicEmissionBeamData()
+ElectromagneticEmissionBeamData::~ElectromagneticEmissionBeamData()
 {
     _trackJamTargets.clear();
 }
 
-unsigned char ElectronicEmissionBeamData::getBeamDataLength() const
+unsigned char ElectromagneticEmissionBeamData::getBeamDataLength() const
 {
     return _beamDataLength;
 }
 
-void ElectronicEmissionBeamData::setBeamDataLength(unsigned char pX)
+void ElectromagneticEmissionBeamData::setBeamDataLength(unsigned char pX)
 {
     _beamDataLength = pX;
 }
 
-unsigned char ElectronicEmissionBeamData::getBeamIDNumber() const
+unsigned char ElectromagneticEmissionBeamData::getBeamIDNumber() const
 {
     return _beamIDNumber;
 }
 
-void ElectronicEmissionBeamData::setBeamIDNumber(unsigned char pX)
+void ElectromagneticEmissionBeamData::setBeamIDNumber(unsigned char pX)
 {
     _beamIDNumber = pX;
 }
 
-unsigned short ElectronicEmissionBeamData::getBeamParameterIndex() const
+unsigned short ElectromagneticEmissionBeamData::getBeamParameterIndex() const
 {
     return _beamParameterIndex;
 }
 
-void ElectronicEmissionBeamData::setBeamParameterIndex(unsigned short pX)
+void ElectromagneticEmissionBeamData::setBeamParameterIndex(unsigned short pX)
 {
     _beamParameterIndex = pX;
 }
 
-FundamentalParameterData& ElectronicEmissionBeamData::getFundamentalParameterData() 
+FundamentalParameterData& ElectromagneticEmissionBeamData::getFundamentalParameterData() 
 {
     return _fundamentalParameterData;
 }
 
-const FundamentalParameterData& ElectronicEmissionBeamData::getFundamentalParameterData() const
+const FundamentalParameterData& ElectromagneticEmissionBeamData::getFundamentalParameterData() const
 {
     return _fundamentalParameterData;
 }
 
-void ElectronicEmissionBeamData::setFundamentalParameterData(const FundamentalParameterData &pX)
+void ElectromagneticEmissionBeamData::setFundamentalParameterData(const FundamentalParameterData &pX)
 {
     _fundamentalParameterData = pX;
 }
 
-unsigned char ElectronicEmissionBeamData::getBeamFunction() const
+unsigned char ElectromagneticEmissionBeamData::getBeamFunction() const
 {
     return _beamFunction;
 }
 
-void ElectronicEmissionBeamData::setBeamFunction(unsigned char pX)
+void ElectromagneticEmissionBeamData::setBeamFunction(unsigned char pX)
 {
     _beamFunction = pX;
 }
 
-unsigned char ElectronicEmissionBeamData::getNumberOfTrackJamTargets() const
+unsigned char ElectromagneticEmissionBeamData::getNumberOfTrackJamTargets() const
 {
    return _trackJamTargets.size();
 }
 
-unsigned char ElectronicEmissionBeamData::getHighDensityTrackJam() const
+unsigned char ElectromagneticEmissionBeamData::getHighDensityTrackJam() const
 {
     return _highDensityTrackJam;
 }
 
-void ElectronicEmissionBeamData::setHighDensityTrackJam(unsigned char pX)
+void ElectromagneticEmissionBeamData::setHighDensityTrackJam(unsigned char pX)
 {
     _highDensityTrackJam = pX;
 }
 
-unsigned char ElectronicEmissionBeamData::getPad4() const
+unsigned char ElectromagneticEmissionBeamData::getPad4() const
 {
     return _pad4;
 }
 
-void ElectronicEmissionBeamData::setPad4(unsigned char pX)
+void ElectromagneticEmissionBeamData::setPad4(unsigned char pX)
 {
     _pad4 = pX;
 }
 
-unsigned int ElectronicEmissionBeamData::getJammingModeSequence() const
+unsigned int ElectromagneticEmissionBeamData::getJammingModeSequence() const
 {
     return _jammingModeSequence;
 }
 
-void ElectronicEmissionBeamData::setJammingModeSequence(unsigned int pX)
+void ElectromagneticEmissionBeamData::setJammingModeSequence(unsigned int pX)
 {
     _jammingModeSequence = pX;
 }
 
-std::vector<TrackJamTarget>& ElectronicEmissionBeamData::getTrackJamTargets() 
+std::vector<TrackJamTarget>& ElectromagneticEmissionBeamData::getTrackJamTargets() 
 {
     return _trackJamTargets;
 }
 
-const std::vector<TrackJamTarget>& ElectronicEmissionBeamData::getTrackJamTargets() const
+const std::vector<TrackJamTarget>& ElectromagneticEmissionBeamData::getTrackJamTargets() const
 {
     return _trackJamTargets;
 }
 
-void ElectronicEmissionBeamData::setTrackJamTargets(const std::vector<TrackJamTarget>& pX)
+void ElectromagneticEmissionBeamData::setTrackJamTargets(const std::vector<TrackJamTarget>& pX)
 {
      _trackJamTargets = pX;
 }
 
-void ElectronicEmissionBeamData::marshal(DataStream& dataStream) const
+void ElectromagneticEmissionBeamData::marshal(DataStream& dataStream) const
 {
     dataStream << _beamDataLength;
     dataStream << _beamIDNumber;
@@ -146,7 +146,7 @@ void ElectronicEmissionBeamData::marshal(DataStream& dataStream) const
 
 }
 
-void ElectronicEmissionBeamData::unmarshal(DataStream& dataStream)
+void ElectromagneticEmissionBeamData::unmarshal(DataStream& dataStream)
 {
     dataStream >> _beamDataLength;
     dataStream >> _beamIDNumber;
@@ -168,7 +168,7 @@ void ElectronicEmissionBeamData::unmarshal(DataStream& dataStream)
 }
 
 
-bool ElectronicEmissionBeamData::operator ==(const ElectronicEmissionBeamData& rhs) const
+bool ElectromagneticEmissionBeamData::operator ==(const ElectromagneticEmissionBeamData& rhs) const
  {
      bool ivarsEqual = true;
 
@@ -190,7 +190,7 @@ bool ElectronicEmissionBeamData::operator ==(const ElectronicEmissionBeamData& r
     return ivarsEqual;
  }
 
-int ElectronicEmissionBeamData::getMarshalledSize() const
+int ElectromagneticEmissionBeamData::getMarshalledSize() const
 {
    int marshalSize = 0;
 

--- a/src/dis6/ElectromagneticEmissionBeamData.h
+++ b/src/dis6/ElectromagneticEmissionBeamData.h
@@ -16,7 +16,7 @@ namespace DIS
 //
 // @author DMcG, jkg
 
-class EXPORT_MACRO ElectronicEmissionBeamData
+class EXPORT_MACRO ElectromagneticEmissionBeamData
 {
 protected:
   /** This field shall specify the length of this beams data in 32 bit words */
@@ -51,8 +51,8 @@ protected:
 
 
  public:
-    ElectronicEmissionBeamData();
-    virtual ~ElectronicEmissionBeamData();
+    ElectromagneticEmissionBeamData();
+    virtual ~ElectromagneticEmissionBeamData();
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
@@ -91,7 +91,7 @@ protected:
 
 virtual int getMarshalledSize() const;
 
-     bool operator  ==(const ElectronicEmissionBeamData& rhs) const;
+     bool operator  ==(const ElectromagneticEmissionBeamData& rhs) const;
 };
 }
 

--- a/src/dis6/ElectromagneticEmissionSystemData.cpp
+++ b/src/dis6/ElectromagneticEmissionSystemData.cpp
@@ -1,9 +1,9 @@
-#include <dis6/ElectronicEmissionSystemData.h>
+#include <dis6/ElectromagneticEmissionSystemData.h>
 
 using namespace DIS;
 
 
-ElectronicEmissionSystemData::ElectronicEmissionSystemData():
+ElectromagneticEmissionSystemData::ElectromagneticEmissionSystemData():
    _systemDataLength(0), 
    _numberOfBeams(0), 
    _emissionsPadding2(0), 
@@ -12,82 +12,82 @@ ElectronicEmissionSystemData::ElectronicEmissionSystemData():
 {
 }
 
-ElectronicEmissionSystemData::~ElectronicEmissionSystemData()
+ElectromagneticEmissionSystemData::~ElectromagneticEmissionSystemData()
 {
     _beamDataRecords.clear();
 }
 
-unsigned char ElectronicEmissionSystemData::getSystemDataLength() const
+unsigned char ElectromagneticEmissionSystemData::getSystemDataLength() const
 {
     return _systemDataLength;
 }
 
-void ElectronicEmissionSystemData::setSystemDataLength(unsigned char pX)
+void ElectromagneticEmissionSystemData::setSystemDataLength(unsigned char pX)
 {
     _systemDataLength = pX;
 }
 
-unsigned char ElectronicEmissionSystemData::getNumberOfBeams() const
+unsigned char ElectromagneticEmissionSystemData::getNumberOfBeams() const
 {
    return _beamDataRecords.size();
 }
 
-unsigned short ElectronicEmissionSystemData::getEmissionsPadding2() const
+unsigned short ElectromagneticEmissionSystemData::getEmissionsPadding2() const
 {
     return _emissionsPadding2;
 }
 
-void ElectronicEmissionSystemData::setEmissionsPadding2(unsigned short pX)
+void ElectromagneticEmissionSystemData::setEmissionsPadding2(unsigned short pX)
 {
     _emissionsPadding2 = pX;
 }
 
-EmitterSystem& ElectronicEmissionSystemData::getEmitterSystem() 
+EmitterSystem& ElectromagneticEmissionSystemData::getEmitterSystem() 
 {
     return _emitterSystem;
 }
 
-const EmitterSystem& ElectronicEmissionSystemData::getEmitterSystem() const
+const EmitterSystem& ElectromagneticEmissionSystemData::getEmitterSystem() const
 {
     return _emitterSystem;
 }
 
-void ElectronicEmissionSystemData::setEmitterSystem(const EmitterSystem &pX)
+void ElectromagneticEmissionSystemData::setEmitterSystem(const EmitterSystem &pX)
 {
     _emitterSystem = pX;
 }
 
-Vector3Float& ElectronicEmissionSystemData::getLocation() 
+Vector3Float& ElectromagneticEmissionSystemData::getLocation() 
 {
     return _location;
 }
 
-const Vector3Float& ElectronicEmissionSystemData::getLocation() const
+const Vector3Float& ElectromagneticEmissionSystemData::getLocation() const
 {
     return _location;
 }
 
-void ElectronicEmissionSystemData::setLocation(const Vector3Float &pX)
+void ElectromagneticEmissionSystemData::setLocation(const Vector3Float &pX)
 {
     _location = pX;
 }
 
-std::vector<ElectronicEmissionBeamData>& ElectronicEmissionSystemData::getBeamDataRecords() 
+std::vector<ElectromagneticEmissionBeamData>& ElectromagneticEmissionSystemData::getBeamDataRecords() 
 {
     return _beamDataRecords;
 }
 
-const std::vector<ElectronicEmissionBeamData>& ElectronicEmissionSystemData::getBeamDataRecords() const
+const std::vector<ElectromagneticEmissionBeamData>& ElectromagneticEmissionSystemData::getBeamDataRecords() const
 {
     return _beamDataRecords;
 }
 
-void ElectronicEmissionSystemData::setBeamDataRecords(const std::vector<ElectronicEmissionBeamData>& pX)
+void ElectromagneticEmissionSystemData::setBeamDataRecords(const std::vector<ElectromagneticEmissionBeamData>& pX)
 {
      _beamDataRecords = pX;
 }
 
-void ElectronicEmissionSystemData::marshal(DataStream& dataStream) const
+void ElectromagneticEmissionSystemData::marshal(DataStream& dataStream) const
 {
     dataStream << _systemDataLength;
     dataStream << ( unsigned char )_beamDataRecords.size();
@@ -97,13 +97,13 @@ void ElectronicEmissionSystemData::marshal(DataStream& dataStream) const
 
      for(size_t idx = 0; idx < _beamDataRecords.size(); idx++)
      {
-        ElectronicEmissionBeamData x = _beamDataRecords[idx];
+        ElectromagneticEmissionBeamData x = _beamDataRecords[idx];
         x.marshal(dataStream);
      }
 
 }
 
-void ElectronicEmissionSystemData::unmarshal(DataStream& dataStream)
+void ElectromagneticEmissionSystemData::unmarshal(DataStream& dataStream)
 {
     dataStream >> _systemDataLength;
     dataStream >> _numberOfBeams;
@@ -114,14 +114,14 @@ void ElectronicEmissionSystemData::unmarshal(DataStream& dataStream)
      _beamDataRecords.clear();
      for(size_t idx = 0; idx < _numberOfBeams; idx++)
      {
-        ElectronicEmissionBeamData x;
+        ElectromagneticEmissionBeamData x;
         x.unmarshal(dataStream);
         _beamDataRecords.push_back(x);
      }
 }
 
 
-bool ElectronicEmissionSystemData::operator ==(const ElectronicEmissionSystemData& rhs) const
+bool ElectromagneticEmissionSystemData::operator ==(const ElectromagneticEmissionSystemData& rhs) const
  {
      bool ivarsEqual = true;
 
@@ -139,7 +139,7 @@ bool ElectronicEmissionSystemData::operator ==(const ElectronicEmissionSystemDat
     return ivarsEqual;
  }
 
-int ElectronicEmissionSystemData::getMarshalledSize() const
+int ElectromagneticEmissionSystemData::getMarshalledSize() const
 {
    int marshalSize = 0;
 
@@ -151,7 +151,7 @@ int ElectronicEmissionSystemData::getMarshalledSize() const
 
    for(unsigned long long idx=0; idx < _beamDataRecords.size(); idx++)
    {
-        ElectronicEmissionBeamData listElement = _beamDataRecords[idx];
+        ElectromagneticEmissionBeamData listElement = _beamDataRecords[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 

--- a/src/dis6/ElectromagneticEmissionSystemData.h
+++ b/src/dis6/ElectromagneticEmissionSystemData.h
@@ -3,7 +3,7 @@
 
 #include <dis6/EmitterSystem.h>
 #include <dis6/Vector3Float.h>
-#include <dis6/ElectronicEmissionBeamData.h>
+#include <dis6/ElectromagneticEmissionBeamData.h>
 #include <vector>
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -17,7 +17,7 @@ namespace DIS
 //
 // @author DMcG, jkg
 
-class EXPORT_MACRO ElectronicEmissionSystemData
+class EXPORT_MACRO ElectromagneticEmissionSystemData
 {
 protected:
   /** This field shall specify the length of this emitter system�s data (including beam data and its track/jam information) in 32-bit words. The length shall include the System Data Length field.  */
@@ -36,12 +36,12 @@ protected:
   Vector3Float _location; 
 
   /** variable length list of beam data records */
-  std::vector<ElectronicEmissionBeamData> _beamDataRecords; 
+  std::vector<ElectromagneticEmissionBeamData> _beamDataRecords; 
 
 
  public:
-    ElectronicEmissionSystemData();
-    virtual ~ElectronicEmissionSystemData();
+    ElectromagneticEmissionSystemData();
+    virtual ~ElectromagneticEmissionSystemData();
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
@@ -62,14 +62,14 @@ protected:
     const Vector3Float&  getLocation() const; 
     void setLocation(const Vector3Float    &pX);
 
-    std::vector<ElectronicEmissionBeamData>& getBeamDataRecords(); 
-    const std::vector<ElectronicEmissionBeamData>& getBeamDataRecords() const; 
-    void setBeamDataRecords(const std::vector<ElectronicEmissionBeamData>&    pX);
+    std::vector<ElectromagneticEmissionBeamData>& getBeamDataRecords(); 
+    const std::vector<ElectromagneticEmissionBeamData>& getBeamDataRecords() const; 
+    void setBeamDataRecords(const std::vector<ElectromagneticEmissionBeamData>&    pX);
 
 
 virtual int getMarshalledSize() const;
 
-     bool operator  ==(const ElectronicEmissionSystemData& rhs) const;
+     bool operator  ==(const ElectromagneticEmissionSystemData& rhs) const;
 };
 }
 

--- a/src/dis6/ElectromagneticEmissionsPdu.cpp
+++ b/src/dis6/ElectromagneticEmissionsPdu.cpp
@@ -1,149 +1,95 @@
-#include <dis7/ElectronicEmissionsPdu.h>
+#include <dis6/ElectromagneticEmissionsPdu.h>
 
 using namespace DIS;
 
 
-ElectronicEmissionsPdu::ElectronicEmissionsPdu() : DistributedEmissionsFamilyPdu(),
+ElectromagneticEmissionsPdu::ElectromagneticEmissionsPdu() : DistributedEmissionsFamilyPdu(),
    _emittingEntityID(), 
    _eventID(), 
    _stateUpdateIndicator(0), 
    _numberOfSystems(0), 
-   _paddingForEmissionsPdu(0), 
-   _systemDataLength(0), 
-   _numberOfBeams(0), 
-   _emitterSystem(), 
-   _location()
+   _paddingForEmissionsPdu(0)
 {
     setPduType( 23 );
     setPaddingForEmissionsPdu( 0 );
 }
 
-ElectronicEmissionsPdu::~ElectronicEmissionsPdu()
+ElectromagneticEmissionsPdu::~ElectromagneticEmissionsPdu()
 {
     _systems.clear();
 }
 
-EntityID& ElectronicEmissionsPdu::getEmittingEntityID() 
+EntityID& ElectromagneticEmissionsPdu::getEmittingEntityID() 
 {
     return _emittingEntityID;
 }
 
-const EntityID& ElectronicEmissionsPdu::getEmittingEntityID() const
+const EntityID& ElectromagneticEmissionsPdu::getEmittingEntityID() const
 {
     return _emittingEntityID;
 }
 
-void ElectronicEmissionsPdu::setEmittingEntityID(const EntityID &pX)
+void ElectromagneticEmissionsPdu::setEmittingEntityID(const EntityID &pX)
 {
     _emittingEntityID = pX;
 }
 
-EventIdentifier& ElectronicEmissionsPdu::getEventID() 
+EventID& ElectromagneticEmissionsPdu::getEventID() 
 {
     return _eventID;
 }
 
-const EventIdentifier& ElectronicEmissionsPdu::getEventID() const
+const EventID& ElectromagneticEmissionsPdu::getEventID() const
 {
     return _eventID;
 }
 
-void ElectronicEmissionsPdu::setEventID(const EventIdentifier &pX)
+void ElectromagneticEmissionsPdu::setEventID(const EventID &pX)
 {
     _eventID = pX;
 }
 
-unsigned char ElectronicEmissionsPdu::getStateUpdateIndicator() const
+unsigned char ElectromagneticEmissionsPdu::getStateUpdateIndicator() const
 {
     return _stateUpdateIndicator;
 }
 
-void ElectronicEmissionsPdu::setStateUpdateIndicator(unsigned char pX)
+void ElectromagneticEmissionsPdu::setStateUpdateIndicator(unsigned char pX)
 {
     _stateUpdateIndicator = pX;
 }
 
-unsigned char ElectronicEmissionsPdu::getNumberOfSystems() const
+unsigned char ElectromagneticEmissionsPdu::getNumberOfSystems() const
 {
    return _systems.size();
 }
 
-unsigned short ElectronicEmissionsPdu::getPaddingForEmissionsPdu() const
+unsigned short ElectromagneticEmissionsPdu::getPaddingForEmissionsPdu() const
 {
     return _paddingForEmissionsPdu;
 }
 
-void ElectronicEmissionsPdu::setPaddingForEmissionsPdu(unsigned short pX)
+void ElectromagneticEmissionsPdu::setPaddingForEmissionsPdu(unsigned short pX)
 {
     _paddingForEmissionsPdu = pX;
 }
 
-unsigned char ElectronicEmissionsPdu::getSystemDataLength() const
-{
-    return _systemDataLength;
-}
-
-void ElectronicEmissionsPdu::setSystemDataLength(unsigned char pX)
-{
-    _systemDataLength = pX;
-}
-
-unsigned char ElectronicEmissionsPdu::getNumberOfBeams() const
-{
-    return _numberOfBeams;
-}
-
-void ElectronicEmissionsPdu::setNumberOfBeams(unsigned char pX)
-{
-    _numberOfBeams = pX;
-}
-
-EmitterSystem& ElectronicEmissionsPdu::getEmitterSystem() 
-{
-    return _emitterSystem;
-}
-
-const EmitterSystem& ElectronicEmissionsPdu::getEmitterSystem() const
-{
-    return _emitterSystem;
-}
-
-void ElectronicEmissionsPdu::setEmitterSystem(const EmitterSystem &pX)
-{
-    _emitterSystem = pX;
-}
-
-Vector3Float& ElectronicEmissionsPdu::getLocation() 
-{
-    return _location;
-}
-
-const Vector3Float& ElectronicEmissionsPdu::getLocation() const
-{
-    return _location;
-}
-
-void ElectronicEmissionsPdu::setLocation(const Vector3Float &pX)
-{
-    _location = pX;
-}
-
-std::vector<Vector3Float>& ElectronicEmissionsPdu::getSystems() 
+std::vector<ElectromagneticEmissionSystemData>& ElectromagneticEmissionsPdu::getSystems() 
 {
     return _systems;
 }
 
-const std::vector<Vector3Float>& ElectronicEmissionsPdu::getSystems() const
+const std::vector<ElectromagneticEmissionSystemData>& ElectromagneticEmissionsPdu::getSystems() const
 {
     return _systems;
 }
 
-void ElectronicEmissionsPdu::setSystems(const std::vector<Vector3Float>& pX)
+void ElectromagneticEmissionsPdu::setSystems(const std::vector<ElectromagneticEmissionSystemData>& pX)
 {
      _systems = pX;
 }
 
-void ElectronicEmissionsPdu::marshal(DataStream& dataStream) const
+void ElectromagneticEmissionsPdu::marshal(DataStream& dataStream) const
 {
     DistributedEmissionsFamilyPdu::marshal(dataStream); // Marshal information in superclass first
     _emittingEntityID.marshal(dataStream);
@@ -151,20 +97,16 @@ void ElectronicEmissionsPdu::marshal(DataStream& dataStream) const
     dataStream << _stateUpdateIndicator;
     dataStream << ( unsigned char )_systems.size();
     dataStream << _paddingForEmissionsPdu;
-    dataStream << _systemDataLength;
-    dataStream << _numberOfBeams;
-    _emitterSystem.marshal(dataStream);
-    _location.marshal(dataStream);
 
      for(size_t idx = 0; idx < _systems.size(); idx++)
      {
-        Vector3Float x = _systems[idx];
+        ElectromagneticEmissionSystemData x = _systems[idx];
         x.marshal(dataStream);
      }
 
 }
 
-void ElectronicEmissionsPdu::unmarshal(DataStream& dataStream)
+void ElectromagneticEmissionsPdu::unmarshal(DataStream& dataStream)
 {
     DistributedEmissionsFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
     _emittingEntityID.unmarshal(dataStream);
@@ -172,22 +114,18 @@ void ElectronicEmissionsPdu::unmarshal(DataStream& dataStream)
     dataStream >> _stateUpdateIndicator;
     dataStream >> _numberOfSystems;
     dataStream >> _paddingForEmissionsPdu;
-    dataStream >> _systemDataLength;
-    dataStream >> _numberOfBeams;
-    _emitterSystem.unmarshal(dataStream);
-    _location.unmarshal(dataStream);
 
      _systems.clear();
      for(size_t idx = 0; idx < _numberOfSystems; idx++)
      {
-        Vector3Float x;
+        ElectromagneticEmissionSystemData x;
         x.unmarshal(dataStream);
         _systems.push_back(x);
      }
 }
 
 
-bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) const
+bool ElectromagneticEmissionsPdu::operator ==(const ElectromagneticEmissionsPdu& rhs) const
  {
      bool ivarsEqual = true;
 
@@ -197,10 +135,6 @@ bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) cons
      if( ! (_eventID == rhs._eventID) ) ivarsEqual = false;
      if( ! (_stateUpdateIndicator == rhs._stateUpdateIndicator) ) ivarsEqual = false;
      if( ! (_paddingForEmissionsPdu == rhs._paddingForEmissionsPdu) ) ivarsEqual = false;
-     if( ! (_systemDataLength == rhs._systemDataLength) ) ivarsEqual = false;
-     if( ! (_numberOfBeams == rhs._numberOfBeams) ) ivarsEqual = false;
-     if( ! (_emitterSystem == rhs._emitterSystem) ) ivarsEqual = false;
-     if( ! (_location == rhs._location) ) ivarsEqual = false;
 
      for(size_t idx = 0; idx < _systems.size(); idx++)
      {
@@ -211,7 +145,7 @@ bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) cons
     return ivarsEqual;
  }
 
-int ElectronicEmissionsPdu::getMarshalledSize() const
+int ElectromagneticEmissionsPdu::getMarshalledSize() const
 {
    int marshalSize = 0;
 
@@ -221,14 +155,10 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _stateUpdateIndicator
    marshalSize = marshalSize + 1;  // _numberOfSystems
    marshalSize = marshalSize + 2;  // _paddingForEmissionsPdu
-   marshalSize = marshalSize + 1;  // _systemDataLength
-   marshalSize = marshalSize + 1;  // _numberOfBeams
-   marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
-   marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
    for(unsigned long long idx=0; idx < _systems.size(); idx++)
    {
-        Vector3Float listElement = _systems[idx];
+        ElectromagneticEmissionSystemData listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 

--- a/src/dis6/ElectromagneticEmissionsPdu.h
+++ b/src/dis6/ElectromagneticEmissionsPdu.h
@@ -3,7 +3,7 @@
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
-#include <dis6/ElectronicEmissionSystemData.h>
+#include <dis6/ElectromagneticEmissionSystemData.h>
 #include <vector>
 #include <dis6/DistributedEmissionsFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -18,7 +18,7 @@ namespace DIS
 //
 // @author DMcG, jkg
 
-class EXPORT_MACRO ElectronicEmissionsPdu : public DistributedEmissionsFamilyPdu
+class EXPORT_MACRO ElectromagneticEmissionsPdu : public DistributedEmissionsFamilyPdu
 {
 protected:
   /** ID of the entity emitting */
@@ -36,13 +36,13 @@ protected:
   /** padding */
   unsigned short _paddingForEmissionsPdu; 
 
-  /** Electronic emmissions systems */
-  std::vector<ElectronicEmissionSystemData> _systems; 
+  /** Electromagnetic emmissions systems */
+  std::vector<ElectromagneticEmissionSystemData> _systems; 
 
 
  public:
-    ElectronicEmissionsPdu();
-    virtual ~ElectronicEmissionsPdu();
+    ElectromagneticEmissionsPdu();
+    virtual ~ElectromagneticEmissionsPdu();
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
@@ -63,14 +63,14 @@ protected:
     unsigned short getPaddingForEmissionsPdu() const; 
     void setPaddingForEmissionsPdu(unsigned short pX); 
 
-    std::vector<ElectronicEmissionSystemData>& getSystems(); 
-    const std::vector<ElectronicEmissionSystemData>& getSystems() const; 
-    void setSystems(const std::vector<ElectronicEmissionSystemData>&    pX);
+    std::vector<ElectromagneticEmissionSystemData>& getSystems(); 
+    const std::vector<ElectromagneticEmissionSystemData>& getSystems() const; 
+    void setSystems(const std::vector<ElectromagneticEmissionSystemData>&    pX);
 
 
 virtual int getMarshalledSize() const;
 
-     bool operator  ==(const ElectronicEmissionsPdu& rhs) const;
+     bool operator  ==(const ElectromagneticEmissionsPdu& rhs) const;
 };
 }
 

--- a/src/dis7/DistributedEmissionsFamilyPdu.h
+++ b/src/dis7/DistributedEmissionsFamilyPdu.h
@@ -8,7 +8,7 @@
 
 namespace DIS
 {
-// Section 5.3.7. Electronic Emissions. Abstract superclass for distirubted emissions PDU
+// Section 5.3.7. Electromagnetic Emissions. Abstract superclass for distirubted emissions PDU
 
 // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
 //

--- a/src/dis7/ElectromagneticEmissionsPdu.cpp
+++ b/src/dis7/ElectromagneticEmissionsPdu.cpp
@@ -1,95 +1,149 @@
-#include <dis6/ElectronicEmissionsPdu.h>
+#include <dis7/ElectromagneticEmissionsPdu.h>
 
 using namespace DIS;
 
 
-ElectronicEmissionsPdu::ElectronicEmissionsPdu() : DistributedEmissionsFamilyPdu(),
+ElectromagneticEmissionsPdu::ElectromagneticEmissionsPdu() : DistributedEmissionsFamilyPdu(),
    _emittingEntityID(), 
    _eventID(), 
    _stateUpdateIndicator(0), 
    _numberOfSystems(0), 
-   _paddingForEmissionsPdu(0)
+   _paddingForEmissionsPdu(0), 
+   _systemDataLength(0), 
+   _numberOfBeams(0), 
+   _emitterSystem(), 
+   _location()
 {
     setPduType( 23 );
     setPaddingForEmissionsPdu( 0 );
 }
 
-ElectronicEmissionsPdu::~ElectronicEmissionsPdu()
+ElectromagneticEmissionsPdu::~ElectromagneticEmissionsPdu()
 {
     _systems.clear();
 }
 
-EntityID& ElectronicEmissionsPdu::getEmittingEntityID() 
+EntityID& ElectromagneticEmissionsPdu::getEmittingEntityID() 
 {
     return _emittingEntityID;
 }
 
-const EntityID& ElectronicEmissionsPdu::getEmittingEntityID() const
+const EntityID& ElectromagneticEmissionsPdu::getEmittingEntityID() const
 {
     return _emittingEntityID;
 }
 
-void ElectronicEmissionsPdu::setEmittingEntityID(const EntityID &pX)
+void ElectromagneticEmissionsPdu::setEmittingEntityID(const EntityID &pX)
 {
     _emittingEntityID = pX;
 }
 
-EventID& ElectronicEmissionsPdu::getEventID() 
+EventIdentifier& ElectromagneticEmissionsPdu::getEventID() 
 {
     return _eventID;
 }
 
-const EventID& ElectronicEmissionsPdu::getEventID() const
+const EventIdentifier& ElectromagneticEmissionsPdu::getEventID() const
 {
     return _eventID;
 }
 
-void ElectronicEmissionsPdu::setEventID(const EventID &pX)
+void ElectromagneticEmissionsPdu::setEventID(const EventIdentifier &pX)
 {
     _eventID = pX;
 }
 
-unsigned char ElectronicEmissionsPdu::getStateUpdateIndicator() const
+unsigned char ElectromagneticEmissionsPdu::getStateUpdateIndicator() const
 {
     return _stateUpdateIndicator;
 }
 
-void ElectronicEmissionsPdu::setStateUpdateIndicator(unsigned char pX)
+void ElectromagneticEmissionsPdu::setStateUpdateIndicator(unsigned char pX)
 {
     _stateUpdateIndicator = pX;
 }
 
-unsigned char ElectronicEmissionsPdu::getNumberOfSystems() const
+unsigned char ElectromagneticEmissionsPdu::getNumberOfSystems() const
 {
    return _systems.size();
 }
 
-unsigned short ElectronicEmissionsPdu::getPaddingForEmissionsPdu() const
+unsigned short ElectromagneticEmissionsPdu::getPaddingForEmissionsPdu() const
 {
     return _paddingForEmissionsPdu;
 }
 
-void ElectronicEmissionsPdu::setPaddingForEmissionsPdu(unsigned short pX)
+void ElectromagneticEmissionsPdu::setPaddingForEmissionsPdu(unsigned short pX)
 {
     _paddingForEmissionsPdu = pX;
 }
 
-std::vector<ElectronicEmissionSystemData>& ElectronicEmissionsPdu::getSystems() 
+unsigned char ElectromagneticEmissionsPdu::getSystemDataLength() const
+{
+    return _systemDataLength;
+}
+
+void ElectromagneticEmissionsPdu::setSystemDataLength(unsigned char pX)
+{
+    _systemDataLength = pX;
+}
+
+unsigned char ElectromagneticEmissionsPdu::getNumberOfBeams() const
+{
+    return _numberOfBeams;
+}
+
+void ElectromagneticEmissionsPdu::setNumberOfBeams(unsigned char pX)
+{
+    _numberOfBeams = pX;
+}
+
+EmitterSystem& ElectromagneticEmissionsPdu::getEmitterSystem() 
+{
+    return _emitterSystem;
+}
+
+const EmitterSystem& ElectromagneticEmissionsPdu::getEmitterSystem() const
+{
+    return _emitterSystem;
+}
+
+void ElectromagneticEmissionsPdu::setEmitterSystem(const EmitterSystem &pX)
+{
+    _emitterSystem = pX;
+}
+
+Vector3Float& ElectromagneticEmissionsPdu::getLocation() 
+{
+    return _location;
+}
+
+const Vector3Float& ElectromagneticEmissionsPdu::getLocation() const
+{
+    return _location;
+}
+
+void ElectromagneticEmissionsPdu::setLocation(const Vector3Float &pX)
+{
+    _location = pX;
+}
+
+std::vector<Vector3Float>& ElectromagneticEmissionsPdu::getSystems() 
 {
     return _systems;
 }
 
-const std::vector<ElectronicEmissionSystemData>& ElectronicEmissionsPdu::getSystems() const
+const std::vector<Vector3Float>& ElectromagneticEmissionsPdu::getSystems() const
 {
     return _systems;
 }
 
-void ElectronicEmissionsPdu::setSystems(const std::vector<ElectronicEmissionSystemData>& pX)
+void ElectromagneticEmissionsPdu::setSystems(const std::vector<Vector3Float>& pX)
 {
      _systems = pX;
 }
 
-void ElectronicEmissionsPdu::marshal(DataStream& dataStream) const
+void ElectromagneticEmissionsPdu::marshal(DataStream& dataStream) const
 {
     DistributedEmissionsFamilyPdu::marshal(dataStream); // Marshal information in superclass first
     _emittingEntityID.marshal(dataStream);
@@ -97,16 +151,20 @@ void ElectronicEmissionsPdu::marshal(DataStream& dataStream) const
     dataStream << _stateUpdateIndicator;
     dataStream << ( unsigned char )_systems.size();
     dataStream << _paddingForEmissionsPdu;
+    dataStream << _systemDataLength;
+    dataStream << _numberOfBeams;
+    _emitterSystem.marshal(dataStream);
+    _location.marshal(dataStream);
 
      for(size_t idx = 0; idx < _systems.size(); idx++)
      {
-        ElectronicEmissionSystemData x = _systems[idx];
+        Vector3Float x = _systems[idx];
         x.marshal(dataStream);
      }
 
 }
 
-void ElectronicEmissionsPdu::unmarshal(DataStream& dataStream)
+void ElectromagneticEmissionsPdu::unmarshal(DataStream& dataStream)
 {
     DistributedEmissionsFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
     _emittingEntityID.unmarshal(dataStream);
@@ -114,18 +172,22 @@ void ElectronicEmissionsPdu::unmarshal(DataStream& dataStream)
     dataStream >> _stateUpdateIndicator;
     dataStream >> _numberOfSystems;
     dataStream >> _paddingForEmissionsPdu;
+    dataStream >> _systemDataLength;
+    dataStream >> _numberOfBeams;
+    _emitterSystem.unmarshal(dataStream);
+    _location.unmarshal(dataStream);
 
      _systems.clear();
      for(size_t idx = 0; idx < _numberOfSystems; idx++)
      {
-        ElectronicEmissionSystemData x;
+        Vector3Float x;
         x.unmarshal(dataStream);
         _systems.push_back(x);
      }
 }
 
 
-bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) const
+bool ElectromagneticEmissionsPdu::operator ==(const ElectromagneticEmissionsPdu& rhs) const
  {
      bool ivarsEqual = true;
 
@@ -135,6 +197,10 @@ bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) cons
      if( ! (_eventID == rhs._eventID) ) ivarsEqual = false;
      if( ! (_stateUpdateIndicator == rhs._stateUpdateIndicator) ) ivarsEqual = false;
      if( ! (_paddingForEmissionsPdu == rhs._paddingForEmissionsPdu) ) ivarsEqual = false;
+     if( ! (_systemDataLength == rhs._systemDataLength) ) ivarsEqual = false;
+     if( ! (_numberOfBeams == rhs._numberOfBeams) ) ivarsEqual = false;
+     if( ! (_emitterSystem == rhs._emitterSystem) ) ivarsEqual = false;
+     if( ! (_location == rhs._location) ) ivarsEqual = false;
 
      for(size_t idx = 0; idx < _systems.size(); idx++)
      {
@@ -145,7 +211,7 @@ bool ElectronicEmissionsPdu::operator ==(const ElectronicEmissionsPdu& rhs) cons
     return ivarsEqual;
  }
 
-int ElectronicEmissionsPdu::getMarshalledSize() const
+int ElectromagneticEmissionsPdu::getMarshalledSize() const
 {
    int marshalSize = 0;
 
@@ -155,10 +221,14 @@ int ElectronicEmissionsPdu::getMarshalledSize() const
    marshalSize = marshalSize + 1;  // _stateUpdateIndicator
    marshalSize = marshalSize + 1;  // _numberOfSystems
    marshalSize = marshalSize + 2;  // _paddingForEmissionsPdu
+   marshalSize = marshalSize + 1;  // _systemDataLength
+   marshalSize = marshalSize + 1;  // _numberOfBeams
+   marshalSize = marshalSize + _emitterSystem.getMarshalledSize();  // _emitterSystem
+   marshalSize = marshalSize + _location.getMarshalledSize();  // _location
 
    for(unsigned long long idx=0; idx < _systems.size(); idx++)
    {
-        ElectronicEmissionSystemData listElement = _systems[idx];
+        Vector3Float listElement = _systems[idx];
         marshalSize = marshalSize + listElement.getMarshalledSize();
     }
 

--- a/src/dis7/ElectromagneticEmissionsPdu.h
+++ b/src/dis7/ElectromagneticEmissionsPdu.h
@@ -20,7 +20,7 @@ namespace DIS
 //
 // @author DMcG, jkg
 
-class EXPORT_MACRO ElectronicEmissionsPdu : public DistributedEmissionsFamilyPdu
+class EXPORT_MACRO ElectromagneticEmissionsPdu : public DistributedEmissionsFamilyPdu
 {
 protected:
   /** ID of the entity emitting */
@@ -50,13 +50,13 @@ protected:
   /** the location of the antenna beam source with respect to the emitting entity's coordinate system. This location shall be the origin of the emitter coordinate system that shall have the same orientation as the entity coordinate system. This field shall be represented by an Entity Coordinate Vector record see 6.2.95  */
   Vector3Float _location; 
 
-  /** Electronic emmissions systems THIS IS WRONG. It has the WRONG class type and will cause problems in any marshalling. */
+  /** Electromagnetic emmissions systems THIS IS WRONG. It has the WRONG class type and will cause problems in any marshalling. */
   std::vector<Vector3Float> _systems; 
 
 
  public:
-    ElectronicEmissionsPdu();
-    virtual ~ElectronicEmissionsPdu();
+    ElectromagneticEmissionsPdu();
+    virtual ~ElectromagneticEmissionsPdu();
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
@@ -98,7 +98,7 @@ protected:
 
 virtual int getMarshalledSize() const;
 
-     bool operator  ==(const ElectronicEmissionsPdu& rhs) const;
+     bool operator  ==(const ElectromagneticEmissionsPdu& rhs) const;
 };
 }
 


### PR DESCRIPTION
This pull request adds Appveyor CI to the project (addressing #39), and makes some improvements to the previous CMake pull request #37.
Successful builds can be seen [here](https://ci.appveyor.com/project/rodneyp290/open-dis-cpp)

CMake Improvements include:
- enabling the importing of OpenDIS6 and/or OpenDIS7 lib into other CMake projects.
  - I've also added a separate CMakeList.txt to the example directory that can be used to test installations via importing OpenDIS6
    - in doing this I altered the example c++ file includes to use the relative includes (eg. `#include "file.h"` instead of `#include <example/file.h>`)
- adding a if statement for defining SDL libs to include, and SDL2main (required by Windows) broke the build on some Linux distributions
- using GNUInstallDir module for better handling of lib install directories on some Linux distributions