### PR TITLE
Fix typo in ReceiverPdu class

### DIFF
--- a/src/dis6/ReceiverPdu.cpp
+++ b/src/dis6/ReceiverPdu.cpp
@@ -6,7 +6,7 @@ using namespace DIS;
 ReceiverPdu::ReceiverPdu() : RadioCommunicationsFamilyPdu(),
    _receiverState(0), 
    _padding1(0), 
-   _receivedPoser(0.0), 
+   _receivedPower(0.0), 
    _transmitterEntityId(), 
    _transmitterRadioId(0)
 {
@@ -37,14 +37,14 @@ void ReceiverPdu::setPadding1(unsigned short pX)
     _padding1 = pX;
 }
 
-float ReceiverPdu::getReceivedPoser() const
+float ReceiverPdu::getReceivedPower() const
 {
-    return _receivedPoser;
+    return _receivedPower;
 }
 
-void ReceiverPdu::setReceivedPoser(float pX)
+void ReceiverPdu::setReceivedPower(float pX)
 {
-    _receivedPoser = pX;
+    _receivedPower = pX;
 }
 
 EntityID& ReceiverPdu::getTransmitterEntityId() 
@@ -77,7 +77,7 @@ void ReceiverPdu::marshal(DataStream& dataStream) const
     RadioCommunicationsFamilyPdu::marshal(dataStream); // Marshal information in superclass first
     dataStream << _receiverState;
     dataStream << _padding1;
-    dataStream << _receivedPoser;
+    dataStream << _receivedPower;
     _transmitterEntityId.marshal(dataStream);
     dataStream << _transmitterRadioId;
 }
@@ -87,7 +87,7 @@ void ReceiverPdu::unmarshal(DataStream& dataStream)
     RadioCommunicationsFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
     dataStream >> _receiverState;
     dataStream >> _padding1;
-    dataStream >> _receivedPoser;
+    dataStream >> _receivedPower;
     _transmitterEntityId.unmarshal(dataStream);
     dataStream >> _transmitterRadioId;
 }
@@ -101,7 +101,7 @@ bool ReceiverPdu::operator ==(const ReceiverPdu& rhs) const
 
      if( ! (_receiverState == rhs._receiverState) ) ivarsEqual = false;
      if( ! (_padding1 == rhs._padding1) ) ivarsEqual = false;
-     if( ! (_receivedPoser == rhs._receivedPoser) ) ivarsEqual = false;
+     if( ! (_receivedPower == rhs._receivedPower) ) ivarsEqual = false;
      if( ! (_transmitterEntityId == rhs._transmitterEntityId) ) ivarsEqual = false;
      if( ! (_transmitterRadioId == rhs._transmitterRadioId) ) ivarsEqual = false;
 

--- a/src/dis6/ReceiverPdu.h
+++ b/src/dis6/ReceiverPdu.h
@@ -25,7 +25,7 @@ protected:
   unsigned short _padding1; 
 
   /** received power */
-  float _receivedPoser; 
+  float _receivedPower; 
 
   /** ID of transmitter */
   EntityID _transmitterEntityId; 
@@ -47,8 +47,8 @@ protected:
     unsigned short getPadding1() const; 
     void setPadding1(unsigned short pX); 
 
-    float getReceivedPoser() const; 
-    void setReceivedPoser(float pX); 
+    float getReceivedPower() const; 
+    void setReceivedPower(float pX); 
 
     EntityID& getTransmitterEntityId(); 
     const EntityID&  getTransmitterEntityId() const; 

--- a/src/dis7/ReceiverPdu.cpp
+++ b/src/dis7/ReceiverPdu.cpp
@@ -6,7 +6,7 @@ using namespace DIS;
 ReceiverPdu::ReceiverPdu() : RadioCommunicationsFamilyPdu(),
    _receiverState(0), 
    _padding1(0), 
-   _receivedPoser(0.0), 
+   _receivedPower(0.0), 
    _transmitterEntityId(), 
    _transmitterRadioId(0)
 {
@@ -37,14 +37,14 @@ void ReceiverPdu::setPadding1(unsigned short pX)
     _padding1 = pX;
 }
 
-float ReceiverPdu::getReceivedPoser() const
+float ReceiverPdu::getReceivedPower() const
 {
-    return _receivedPoser;
+    return _receivedPower;
 }
 
-void ReceiverPdu::setReceivedPoser(float pX)
+void ReceiverPdu::setReceivedPower(float pX)
 {
-    _receivedPoser = pX;
+    _receivedPower = pX;
 }
 
 EntityID& ReceiverPdu::getTransmitterEntityId() 
@@ -77,7 +77,7 @@ void ReceiverPdu::marshal(DataStream& dataStream) const
     RadioCommunicationsFamilyPdu::marshal(dataStream); // Marshal information in superclass first
     dataStream << _receiverState;
     dataStream << _padding1;
-    dataStream << _receivedPoser;
+    dataStream << _receivedPower;
     _transmitterEntityId.marshal(dataStream);
     dataStream << _transmitterRadioId;
 }
@@ -87,7 +87,7 @@ void ReceiverPdu::unmarshal(DataStream& dataStream)
     RadioCommunicationsFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
     dataStream >> _receiverState;
     dataStream >> _padding1;
-    dataStream >> _receivedPoser;
+    dataStream >> _receivedPower;
     _transmitterEntityId.unmarshal(dataStream);
     dataStream >> _transmitterRadioId;
 }
@@ -101,7 +101,7 @@ bool ReceiverPdu::operator ==(const ReceiverPdu& rhs) const
 
      if( ! (_receiverState == rhs._receiverState) ) ivarsEqual = false;
      if( ! (_padding1 == rhs._padding1) ) ivarsEqual = false;
-     if( ! (_receivedPoser == rhs._receivedPoser) ) ivarsEqual = false;
+     if( ! (_receivedPower == rhs._receivedPower) ) ivarsEqual = false;
      if( ! (_transmitterEntityId == rhs._transmitterEntityId) ) ivarsEqual = false;
      if( ! (_transmitterRadioId == rhs._transmitterRadioId) ) ivarsEqual = false;
 

--- a/src/dis7/ReceiverPdu.h
+++ b/src/dis7/ReceiverPdu.h
@@ -25,7 +25,7 @@ protected:
   unsigned short _padding1; 
 
   /** received power */
-  float _receivedPoser; 
+  float _receivedPower; 
 
   /** ID of transmitter */
   EntityID _transmitterEntityId; 
@@ -47,8 +47,8 @@ protected:
     unsigned short getPadding1() const; 
     void setPadding1(unsigned short pX); 
 
-    float getReceivedPoser() const; 
-    void setReceivedPoser(float pX); 
+    float getReceivedPower() const; 
+    void setReceivedPower(float pX); 
 
     EntityID& getTransmitterEntityId(); 
     const EntityID&  getTransmitterEntityId() const; 


### PR DESCRIPTION
Fixes small typo in ReceiverPdu class (`receivedPoser` to `receivedPower`).