### PR TITLE
Transmitter PDU has been copied from DIS 6 to DIS 7 folder.

### DIFF
--- a/src/dis7/TransmitterPdu.cpp
+++ b/src/dis7/TransmitterPdu.cpp
@@ -1,0 +1,404 @@
+#include <dis7/TransmitterPdu.h>
+
+using namespace DIS;
+
+
+TransmitterPdu::TransmitterPdu() : RadioCommunicationsFamilyPdu(),
+   _radioType(), 
+   _transmitState(0), 
+   _inputSource(0), 
+   _padding1(0), 
+   _antennaLocation(), 
+   _antennaPatternType(0), 
+   _antennaPatternCount(0), 
+   _frequency(0), 
+   _transmitFrequencyBandwidth(0.0), 
+   _power(0.0), 
+   _modulationType(), 
+   _cryptoSystem(0), 
+   _cryptoKeyId(0), 
+   _modulationParameterCount(0), 
+   _padding2(0), 
+   _padding3(0)
+{
+    setPduType( 25 );
+}
+
+TransmitterPdu::~TransmitterPdu()
+{
+    _modulationParametersList.clear();
+    _antennaPatternList.clear();
+}
+
+RadioType& TransmitterPdu::getRadioType() 
+{
+    return _radioType;
+}
+
+const RadioType& TransmitterPdu::getRadioType() const
+{
+    return _radioType;
+}
+
+void TransmitterPdu::setRadioType(const RadioType &pX)
+{
+    _radioType = pX;
+}
+
+unsigned char TransmitterPdu::getTransmitState() const
+{
+    return _transmitState;
+}
+
+void TransmitterPdu::setTransmitState(unsigned char pX)
+{
+    _transmitState = pX;
+}
+
+unsigned char TransmitterPdu::getInputSource() const
+{
+    return _inputSource;
+}
+
+void TransmitterPdu::setInputSource(unsigned char pX)
+{
+    _inputSource = pX;
+}
+
+unsigned short TransmitterPdu::getPadding1() const
+{
+    return _padding1;
+}
+
+void TransmitterPdu::setPadding1(unsigned short pX)
+{
+    _padding1 = pX;
+}
+
+AntennaLocation& TransmitterPdu::getAntennaLocation()
+{
+    return _antennaLocation;
+}
+
+const AntennaLocation& TransmitterPdu::getAntennaLocation() const
+{
+    return _antennaLocation;
+}
+
+void TransmitterPdu::setAntennaLocation(const AntennaLocation&pX)
+{
+    _antennaLocation = pX;
+}
+
+unsigned short TransmitterPdu::getAntennaPatternType() const
+{
+    return _antennaPatternType;
+}
+
+void TransmitterPdu::setAntennaPatternType(unsigned short pX)
+{
+    _antennaPatternType = pX;
+}
+
+unsigned short TransmitterPdu::getAntennaPatternCount() const
+{
+   return _antennaPatternList.size();
+}
+
+unsigned long long TransmitterPdu::getFrequency() const
+{
+    return _frequency;
+}
+
+void TransmitterPdu::setFrequency(unsigned long long pX)
+{
+    _frequency = pX;
+}
+
+float TransmitterPdu::getTransmitFrequencyBandwidth() const
+{
+    return _transmitFrequencyBandwidth;
+}
+
+void TransmitterPdu::setTransmitFrequencyBandwidth(float pX)
+{
+    _transmitFrequencyBandwidth = pX;
+}
+
+float TransmitterPdu::getPower() const
+{
+    return _power;
+}
+
+void TransmitterPdu::setPower(float pX)
+{
+    _power = pX;
+}
+
+ModulationType& TransmitterPdu::getModulationType() 
+{
+    return _modulationType;
+}
+
+const ModulationType& TransmitterPdu::getModulationType() const
+{
+    return _modulationType;
+}
+
+void TransmitterPdu::setModulationType(const ModulationType &pX)
+{
+    _modulationType = pX;
+}
+
+unsigned short TransmitterPdu::getCryptoSystem() const
+{
+    return _cryptoSystem;
+}
+
+void TransmitterPdu::setCryptoSystem(unsigned short pX)
+{
+    _cryptoSystem = pX;
+}
+
+unsigned short TransmitterPdu::getCryptoKeyId() const
+{
+    return _cryptoKeyId;
+}
+
+void TransmitterPdu::setCryptoKeyId(unsigned short pX)
+{
+    _cryptoKeyId = pX;
+}
+
+unsigned char TransmitterPdu::getModulationParameterCount() const
+{
+   return _modulationParametersList.size();
+}
+
+unsigned short TransmitterPdu::getPadding2() const
+{
+    return _padding2;
+}
+
+void TransmitterPdu::setPadding2(unsigned short pX)
+{
+    _padding2 = pX;
+}
+
+unsigned char TransmitterPdu::getPadding3() const
+{
+    return _padding3;
+}
+
+void TransmitterPdu::setPadding3(unsigned char pX)
+{
+    _padding3 = pX;
+}
+
+std::vector<Vector3Float>& TransmitterPdu::getModulationParametersList() 
+{
+    return _modulationParametersList;
+}
+
+const std::vector<Vector3Float>& TransmitterPdu::getModulationParametersList() const
+{
+    return _modulationParametersList;
+}
+
+void TransmitterPdu::setModulationParametersList(const std::vector<Vector3Float>& pX)
+{
+     _modulationParametersList = pX;
+}
+
+std::vector<Vector3Float>& TransmitterPdu::getAntennaPatternList() 
+{
+    return _antennaPatternList;
+}
+
+const std::vector<Vector3Float>& TransmitterPdu::getAntennaPatternList() const
+{
+    return _antennaPatternList;
+}
+
+void TransmitterPdu::setAntennaPatternList(const std::vector<Vector3Float>& pX)
+{
+     _antennaPatternList = pX;
+}
+
+void TransmitterPdu::marshal(DataStream& dataStream) const
+{
+    RadioCommunicationsFamilyPdu::marshal(dataStream); // Marshal information in superclass first
+    _radioType.marshal(dataStream);
+    dataStream << _transmitState;
+    dataStream << _inputSource;
+    dataStream << _padding1;
+    _antennaLocation.marshal(dataStream);    
+    dataStream << _antennaPatternType;
+    dataStream << ( unsigned short )_antennaPatternList.size();
+    dataStream << _frequency;
+    dataStream << _transmitFrequencyBandwidth;
+    dataStream << _power;
+    _modulationType.marshal(dataStream);
+    dataStream << _cryptoSystem;
+    dataStream << _cryptoKeyId;
+    dataStream << ( unsigned char )_modulationParametersList.size();
+    dataStream << _padding2;
+    dataStream << _padding3;
+
+     for(size_t idx = 0; idx < _modulationParametersList.size(); idx++)
+     {
+        Vector3Float x = _modulationParametersList[idx];
+        x.marshal(dataStream);
+     }
+
+
+     for(size_t idx = 0; idx < _antennaPatternList.size(); idx++)
+     {
+        Vector3Float x = _antennaPatternList[idx];
+        x.marshal(dataStream);
+     }
+
+}
+
+void TransmitterPdu::unmarshal(DataStream& dataStream)
+{
+    RadioCommunicationsFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
+    _radioType.unmarshal(dataStream);
+    dataStream >> _transmitState;
+    dataStream >> _inputSource;
+    dataStream >> _padding1;
+    _antennaLocation.unmarshal(dataStream);    
+    dataStream >> _antennaPatternType;
+    dataStream >> _antennaPatternCount;
+    dataStream >> _frequency;
+    dataStream >> _transmitFrequencyBandwidth;
+    dataStream >> _power;
+    _modulationType.unmarshal(dataStream);
+    dataStream >> _cryptoSystem;
+    dataStream >> _cryptoKeyId;
+    dataStream >> _modulationParameterCount;
+    dataStream >> _padding2;
+    dataStream >> _padding3;
+
+     _modulationParametersList.clear();
+     for(size_t idx = 0; idx < _modulationParameterCount; idx++)
+     {
+        Vector3Float x;
+        x.unmarshal(dataStream);
+        _modulationParametersList.push_back(x);
+     }
+
+     _antennaPatternList.clear();
+     for(size_t idx = 0; idx < _antennaPatternCount; idx++)
+     {
+        Vector3Float x;
+        x.unmarshal(dataStream);
+        _antennaPatternList.push_back(x);
+     }
+}
+
+
+bool TransmitterPdu::operator ==(const TransmitterPdu& rhs) const
+ {
+     bool ivarsEqual = true;
+
+     ivarsEqual = RadioCommunicationsFamilyPdu::operator==(rhs);
+
+     if( ! (_radioType == rhs._radioType) ) ivarsEqual = false;
+     if( ! (_transmitState == rhs._transmitState) ) ivarsEqual = false;
+     if( ! (_inputSource == rhs._inputSource) ) ivarsEqual = false;
+     if( ! (_padding1 == rhs._padding1) ) ivarsEqual = false;
+     if( ! (_antennaLocation == rhs._antennaLocation) ) ivarsEqual = false;     
+     if( ! (_antennaPatternType == rhs._antennaPatternType) ) ivarsEqual = false;
+     if( ! (_frequency == rhs._frequency) ) ivarsEqual = false;
+     if( ! (_transmitFrequencyBandwidth == rhs._transmitFrequencyBandwidth) ) ivarsEqual = false;
+     if( ! (_power == rhs._power) ) ivarsEqual = false;
+     if( ! (_modulationType == rhs._modulationType) ) ivarsEqual = false;
+     if( ! (_cryptoSystem == rhs._cryptoSystem) ) ivarsEqual = false;
+     if( ! (_cryptoKeyId == rhs._cryptoKeyId) ) ivarsEqual = false;
+     if( ! (_padding2 == rhs._padding2) ) ivarsEqual = false;
+     if( ! (_padding3 == rhs._padding3) ) ivarsEqual = false;
+
+     for(size_t idx = 0; idx < _modulationParametersList.size(); idx++)
+     {
+        if( ! ( _modulationParametersList[idx] == rhs._modulationParametersList[idx]) ) ivarsEqual = false;
+     }
+
+
+     for(size_t idx = 0; idx < _antennaPatternList.size(); idx++)
+     {
+        if( ! ( _antennaPatternList[idx] == rhs._antennaPatternList[idx]) ) ivarsEqual = false;
+     }
+
+
+    return ivarsEqual;
+ }
+
+int TransmitterPdu::getMarshalledSize() const
+{
+   int marshalSize = 0;
+
+   marshalSize = RadioCommunicationsFamilyPdu::getMarshalledSize();
+   marshalSize = marshalSize + _radioType.getMarshalledSize();  // _radioEntityType
+   marshalSize = marshalSize + 1;  // _transmitState
+   marshalSize = marshalSize + 1;  // _inputSource
+   marshalSize = marshalSize + 2;  // _padding1
+   marshalSize = marshalSize + _antennaLocation.getMarshalledSize();  // _antennaLocation   
+   marshalSize = marshalSize + 2;  // _antennaPatternType
+   marshalSize = marshalSize + 2;  // _antennaPatternCount
+   marshalSize = marshalSize + 8;  // _frequency
+   marshalSize = marshalSize + 4;  // _transmitFrequencyBandwidth
+   marshalSize = marshalSize + 4;  // _power
+   marshalSize = marshalSize + _modulationType.getMarshalledSize();  // _modulationType
+   marshalSize = marshalSize + 2;  // _cryptoSystem
+   marshalSize = marshalSize + 2;  // _cryptoKeyId
+   marshalSize = marshalSize + 1;  // _modulationParameterCount
+   marshalSize = marshalSize + 2;  // _padding2
+   marshalSize = marshalSize + 1;  // _padding3
+
+   for(unsigned long long idx=0; idx < _modulationParametersList.size(); idx++)
+   {
+        Vector3Float listElement = _modulationParametersList[idx];
+        marshalSize = marshalSize + listElement.getMarshalledSize();
+    }
+
+
+   for(unsigned long long idx=0; idx < _antennaPatternList.size(); idx++)
+   {
+        Vector3Float listElement = _antennaPatternList[idx];
+        marshalSize = marshalSize + listElement.getMarshalledSize();
+    }
+
+    return marshalSize;
+}
+
+// Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+//  are met:
+// 
+//  * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// * Neither the names of the Naval Postgraduate School (NPS)
+//  Modeling Virtual Environments and Simulation (MOVES) Institute
+// (http://www.nps.edu and http://www.MovesInstitute.org)
+// nor the names of its contributors may be used to endorse or
+//  promote products derived from this software without specific
+// prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.

--- a/src/dis7/TransmitterPdu.h
+++ b/src/dis7/TransmitterPdu.h
@@ -1,0 +1,184 @@
+#ifndef TRANSMITTERPDU_H
+#define TRANSMITTERPDU_H
+
+#include <dis7/RadioType.h>
+#include <dis7/Vector3Double.h>
+#include <dis7/Vector3Float.h>
+#include <dis7/ModulationType.h>
+#include <dis7/Vector3Float.h>
+#include <dis7/Vector3Float.h>
+#include <vector>
+#include <dis7/RadioCommunicationsFamilyPdu.h>
+#include <utils/DataStream.h>
+#include <dis7/msLibMacro.h>
+#include <dis7/AntennaLocation.h>
+
+
+namespace DIS
+{
+// Section 5.3.8.1. Detailed information about a radio transmitter. This PDU requires manually         written code to complete, since the modulation parameters are of variable length. UNFINISHED
+
+// Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All rights reserved. 
+//
+// @author DMcG, jkg
+
+class EXPORT_MACRO TransmitterPdu : public RadioCommunicationsFamilyPdu
+{
+protected:
+  /** linear accelleration of entity */
+  RadioType _radioType; 
+
+  /** transmit state */
+  unsigned char _transmitState; 
+
+  /** input source */
+  unsigned char _inputSource; 
+
+  /** padding */
+  unsigned short _padding1; 
+
+  /** Location of antenna */
+  AntennaLocation _antennaLocation; 
+
+  /** antenna pattern type */
+  unsigned short _antennaPatternType; 
+
+  /** atenna pattern length */
+  unsigned short _antennaPatternCount; 
+
+  /** frequency */
+  unsigned long long _frequency;
+
+  /** transmit frequency Bandwidth */
+  float _transmitFrequencyBandwidth; 
+
+  /** transmission power */
+  float _power; 
+
+  /** modulation */
+  ModulationType _modulationType; 
+
+  /** crypto system enumeration */
+  unsigned short _cryptoSystem; 
+
+  /** crypto system key identifer */
+  unsigned short _cryptoKeyId; 
+
+  /** how many modulation parameters we have */
+  unsigned char _modulationParameterCount; 
+
+  /** padding2 */
+  unsigned short _padding2; 
+
+  /** padding3 */
+  unsigned char _padding3; 
+
+  /** variable length list of modulation parameters */
+  std::vector<Vector3Float> _modulationParametersList; 
+
+  /** variable length list of antenna pattern records */
+  std::vector<Vector3Float> _antennaPatternList; 
+
+
+ public:
+    TransmitterPdu();
+    virtual ~TransmitterPdu();
+
+    virtual void marshal(DataStream& dataStream) const;
+    virtual void unmarshal(DataStream& dataStream);
+
+    RadioType& getRadioType(); 
+    const RadioType&  getRadioType() const; 
+    void setRadioType(const RadioType    &pX);
+
+    unsigned char getTransmitState() const; 
+    void setTransmitState(unsigned char pX); 
+
+    unsigned char getInputSource() const; 
+    void setInputSource(unsigned char pX); 
+
+    unsigned short getPadding1() const; 
+    void setPadding1(unsigned short pX); 
+
+    AntennaLocation& getAntennaLocation(); 
+    const AntennaLocation&  getAntennaLocation() const;
+    void setAntennaLocation(const AntennaLocation&pX);
+
+    unsigned short getAntennaPatternType() const; 
+    void setAntennaPatternType(unsigned short pX); 
+
+    unsigned short getAntennaPatternCount() const; 
+
+    unsigned long long getFrequency() const;
+    void setFrequency(unsigned long long pX);
+
+    float getTransmitFrequencyBandwidth() const; 
+    void setTransmitFrequencyBandwidth(float pX); 
+
+    float getPower() const; 
+    void setPower(float pX); 
+
+    ModulationType& getModulationType(); 
+    const ModulationType&  getModulationType() const; 
+    void setModulationType(const ModulationType    &pX);
+
+    unsigned short getCryptoSystem() const; 
+    void setCryptoSystem(unsigned short pX); 
+
+    unsigned short getCryptoKeyId() const; 
+    void setCryptoKeyId(unsigned short pX); 
+
+    unsigned char getModulationParameterCount() const; 
+
+    unsigned short getPadding2() const; 
+    void setPadding2(unsigned short pX); 
+
+    unsigned char getPadding3() const; 
+    void setPadding3(unsigned char pX); 
+
+    std::vector<Vector3Float>& getModulationParametersList(); 
+    const std::vector<Vector3Float>& getModulationParametersList() const; 
+    void setModulationParametersList(const std::vector<Vector3Float>&    pX);
+
+    std::vector<Vector3Float>& getAntennaPatternList(); 
+    const std::vector<Vector3Float>& getAntennaPatternList() const; 
+    void setAntennaPatternList(const std::vector<Vector3Float>&    pX);
+
+
+virtual int getMarshalledSize() const;
+
+     bool operator  ==(const TransmitterPdu& rhs) const;
+};
+}
+
+#endif
+// Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+//  are met:
+// 
+//  * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+// * Neither the names of the Naval Postgraduate School (NPS)
+//  Modeling Virtual Environments and Simulation (MOVES) Institute
+// (http://www.nps.edu and http://www.MovesInstitute.org)
+// nor the names of its contributors may be used to endorse or
+//  promote products derived from this software without specific
+// prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Only changes have been made:
- TransmitterPDU copied from include/dis6 to include/dis7.
- AntennaLocation is used which covers both antennaLocation and relativeAntennaLocation.
- RadioEntityType has been changed to RadioType.
It now successfully compiles.

As I see TransmitterPDU is not deprecated on DIS 7 and it exists on Java repository. I've copied exactly the same file which was on dis6 to dis7 folder. After that to be able to compile the project , I've changed RadioEntityType has been changed to RadioType. Then, there is a new class in DIS 7 called as AntennaLocation which contains relativeAntennaLocation and antennaLocation inside of it so I used that new class and made changes accordingly. 

There might be new updates if you can validate whether [DIS v6 versus v7](https://www.sisostds.org/DesktopModules/Bring2mind/DMX/API/Entries/Download?Command=Core_Download&EntryId=36292&PortalId=0&TabId=105) this document is valid because I've exactly copied TransmitterPdu from DIS 6 which may not cover new updates. 