### PR TITLE
Replace Include Guards with #pragma once (Issue #51)

### DIFF
--- a/examples/Connection.h
+++ b/examples/Connection.h
@@ -1,5 +1,4 @@
-#ifndef _example_dis_connection_h_
-#define _example_dis_connection_h_
+#pragma once
 
 #include <string>                        // for param
 #include <cstddef>                       // for size_t definition
@@ -38,4 +37,3 @@ namespace Example
    };
 }
 
-#endif  // _example_dis_connection_h_

--- a/examples/EntityStatePduProcessor.h
+++ b/examples/EntityStatePduProcessor.h
@@ -1,5 +1,4 @@
-#ifndef _example_entity_state_pdu_processor_h_
-#define _example_entity_state_pdu_processor_h_
+#pragma once
 
 #include <dis6/EntityStatePdu.h>                  // for typedef
 #include <utils/IPacketProcessor.h>                // for base class
@@ -15,4 +14,3 @@ namespace Example
    };
 }
 
-#endif  // _example_entity_state_pdu_processor_h_

--- a/examples/Logging.h
+++ b/examples/Logging.h
@@ -1,5 +1,4 @@
-#ifndef _example_logging_h_
-#define _example_logging_h_
+#pragma once
 
 #include <iostream>
 
@@ -9,4 +8,3 @@
 #define LOG_WARNING(text) \
    std::cerr << text << std::endl;
 
-#endif  // _example_logging_h_

--- a/examples/Timer.h
+++ b/examples/Timer.h
@@ -1,5 +1,4 @@
-#ifndef _example_timer_h_
-#define _example_timer_h_
+#pragma once
 
 #include <SDL.h>
 #include <SDL_timer.h>
@@ -21,4 +20,3 @@ namespace Example
    };
 }
 
-#endif  // _example_timer_h_

--- a/examples/Utils.h
+++ b/examples/Utils.h
@@ -1,5 +1,4 @@
-#ifndef _example_utils_h_
-#define _example_utils_h_
+#pragma once
 
 #include <string>
 #include <sstream>
@@ -148,4 +147,3 @@ namespace Example
    }
 }
 
-#endif  // _example_utils_h_

--- a/src/dis6/AcknowledgePdu.h
+++ b/src/dis6/AcknowledgePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACKNOWLEDGEPDU_H
-#define ACKNOWLEDGEPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -50,7 +49,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcknowledgeReliablePdu.h
+++ b/src/dis6/AcknowledgeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACKNOWLEDGERELIABLEPDU_H
-#define ACKNOWLEDGERELIABLEPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -50,7 +49,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcousticBeamData.h
+++ b/src/dis6/AcousticBeamData.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICBEAMDATA_H
-#define ACOUSTICBEAMDATA_H
+#pragma once
 
 #include <dis6/AcousticBeamFundamentalParameter.h>
 #include <utils/DataStream.h>
@@ -57,7 +56,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcousticBeamFundamentalParameter.h
+++ b/src/dis6/AcousticBeamFundamentalParameter.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICBEAMFUNDAMENTALPARAMETER_H
-#define ACOUSTICBEAMFUNDAMENTALPARAMETER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcousticEmitter.h
+++ b/src/dis6/AcousticEmitter.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICEMITTER_H
-#define ACOUSTICEMITTER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcousticEmitterSystem.h
+++ b/src/dis6/AcousticEmitterSystem.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICEMITTERSYSTEM_H
-#define ACOUSTICEMITTERSYSTEM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AcousticEmitterSystemData.h
+++ b/src/dis6/AcousticEmitterSystemData.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICEMITTERSYSTEMDATA_H
-#define ACOUSTICEMITTERSYSTEMDATA_H
+#pragma once
 
 #include <dis6/AcousticEmitterSystem.h>
 #include <dis6/Vector3Float.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ActionRequestPdu.h
+++ b/src/dis6/ActionRequestPdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONREQUESTPDU_H
-#define ACTIONREQUESTPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ActionRequestReliablePdu.h
+++ b/src/dis6/ActionRequestReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONREQUESTRELIABLEPDU_H
-#define ACTIONREQUESTRELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -89,7 +88,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ActionResponsePdu.h
+++ b/src/dis6/ActionResponsePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONRESPONSEPDU_H
-#define ACTIONRESPONSEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ActionResponseReliablePdu.h
+++ b/src/dis6/ActionResponseReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONRESPONSERELIABLEPDU_H
-#define ACTIONRESPONSERELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AggregateID.h
+++ b/src/dis6/AggregateID.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATEID_H
-#define AGGREGATEID_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AggregateMarking.h
+++ b/src/dis6/AggregateMarking.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATEMARKING_H
-#define AGGREGATEMARKING_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AggregateStatePdu.h
+++ b/src/dis6/AggregateStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATESTATEPDU_H
-#define AGGREGATESTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityType.h>
@@ -178,7 +177,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AggregateType.h
+++ b/src/dis6/AggregateType.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATETYPE_H
-#define AGGREGATETYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AngularVelocityVector.h
+++ b/src/dis6/AngularVelocityVector.h
@@ -1,5 +1,4 @@
-#ifndef ANGULARVELOCITYVECTOR_H
-#define ANGULARVELOCITYVECTOR_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/AntennaLocation.h
+++ b/src/dis6/AntennaLocation.h
@@ -1,5 +1,4 @@
-#ifndef ANTENNALOCATION_H
-#define ANTENNALOCATION_H
+#pragma once
 
 #include <dis6/Vector3Double.h>
 #include <dis6/Vector3Float.h>
@@ -47,7 +46,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ApaData.h
+++ b/src/dis6/ApaData.h
@@ -1,5 +1,4 @@
-#ifndef APADATA_H
-#define APADATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ArealObjectStatePdu.h
+++ b/src/dis6/ArealObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef AREALOBJECTSTATEPDU_H
-#define AREALOBJECTSTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -112,7 +111,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ArticulationParameter.h
+++ b/src/dis6/ArticulationParameter.h
@@ -1,5 +1,4 @@
-#ifndef ARTICULATIONPARAMETER_H
-#define ARTICULATIONPARAMETER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -56,7 +55,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/BeamAntennaPattern.h
+++ b/src/dis6/BeamAntennaPattern.h
@@ -1,5 +1,4 @@
-#ifndef BEAMANTENNAPATTERN_H
-#define BEAMANTENNAPATTERN_H
+#pragma once
 
 #include <dis6/Orientation.h>
 #include <utils/DataStream.h>
@@ -77,7 +76,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/BeamData.h
+++ b/src/dis6/BeamData.h
@@ -1,5 +1,4 @@
-#ifndef BEAMDATA_H
-#define BEAMDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/BurstDescriptor.h
+++ b/src/dis6/BurstDescriptor.h
@@ -1,5 +1,4 @@
-#ifndef BURSTDESCRIPTOR_H
-#define BURSTDESCRIPTOR_H
+#pragma once
 
 #include <dis6/EntityType.h>
 #include <utils/DataStream.h>
@@ -63,7 +62,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ClockTime.h
+++ b/src/dis6/ClockTime.h
@@ -1,5 +1,4 @@
-#ifndef CLOCKTIME_H
-#define CLOCKTIME_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CollisionElasticPdu.h
+++ b/src/dis6/CollisionElasticPdu.h
@@ -1,5 +1,4 @@
-#ifndef COLLISIONELASTICPDU_H
-#define COLLISIONELASTICPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -134,7 +133,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CollisionPdu.h
+++ b/src/dis6/CollisionPdu.h
@@ -1,5 +1,4 @@
-#ifndef COLLISIONPDU_H
-#define COLLISIONPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -90,7 +89,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CommentPdu.h
+++ b/src/dis6/CommentPdu.h
@@ -1,5 +1,4 @@
-#ifndef COMMENTPDU_H
-#define COMMENTPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -59,7 +58,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CommentReliablePdu.h
+++ b/src/dis6/CommentReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef COMMENTRELIABLEPDU_H
-#define COMMENTRELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -59,7 +58,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CreateEntityPdu.h
+++ b/src/dis6/CreateEntityPdu.h
@@ -1,5 +1,4 @@
-#ifndef CREATEENTITYPDU_H
-#define CREATEENTITYPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/CreateEntityReliablePdu.h
+++ b/src/dis6/CreateEntityReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef CREATEENTITYRELIABLEPDU_H
-#define CREATEENTITYRELIABLEPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -56,7 +55,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DataPdu.h
+++ b/src/dis6/DataPdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAPDU_H
-#define DATAPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DataQueryPdu.h
+++ b/src/dis6/DataQueryPdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAQUERYPDU_H
-#define DATAQUERYPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DataQueryReliablePdu.h
+++ b/src/dis6/DataQueryReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAQUERYRELIABLEPDU_H
-#define DATAQUERYRELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -89,7 +88,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DataReliablePdu.h
+++ b/src/dis6/DataReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef DATARELIABLEPDU_H
-#define DATARELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -83,7 +82,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DeadReckoningParameter.h
+++ b/src/dis6/DeadReckoningParameter.h
@@ -1,5 +1,4 @@
-#ifndef DEADRECKONINGPARAMETER_H
-#define DEADRECKONINGPARAMETER_H
+#pragma once
 
 #include <dis6/Vector3Float.h>
 #include <dis6/Vector3Float.h>
@@ -60,7 +59,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DesignatorPdu.h
+++ b/src/dis6/DesignatorPdu.h
@@ -1,5 +1,4 @@
-#ifndef DESIGNATORPDU_H
-#define DESIGNATORPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -114,7 +113,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DetonationPdu.h
+++ b/src/dis6/DetonationPdu.h
@@ -1,5 +1,4 @@
-#ifndef DETONATIONPDU_H
-#define DETONATIONPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
@@ -105,7 +104,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/DistributedEmissionsFamilyPdu.h
+++ b/src/dis6/DistributedEmissionsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef DISTRIBUTEDEMISSIONSFAMILYPDU_H
-#define DISTRIBUTEDEMISSIONSFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EightByteChunk.h
+++ b/src/dis6/EightByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef EIGHTBYTECHUNK_H
-#define EIGHTBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ElectromagneticEmissionBeamData.h
+++ b/src/dis6/ElectromagneticEmissionBeamData.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRONICEMISSIONBEAMDATA_H
-#define ELECTRONICEMISSIONBEAMDATA_H
+#pragma once
 
 #include <dis6/FundamentalParameterData.h>
 #include <dis6/TrackJamTarget.h>
@@ -95,7 +94,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ElectromagneticEmissionSystemData.h
+++ b/src/dis6/ElectromagneticEmissionSystemData.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRONICEMISSIONSYSTEMDATA_H
-#define ELECTRONICEMISSIONSYSTEMDATA_H
+#pragma once
 
 #include <dis6/EmitterSystem.h>
 #include <dis6/Vector3Float.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ElectromagneticEmissionsPdu.h
+++ b/src/dis6/ElectromagneticEmissionsPdu.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRONICEMISSIONSPDU_H
-#define ELECTRONICEMISSIONSPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
@@ -74,7 +73,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EmitterSystem.h
+++ b/src/dis6/EmitterSystem.h
@@ -1,5 +1,4 @@
-#ifndef EMITTERSYSTEM_H
-#define EMITTERSYSTEM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityID.h
+++ b/src/dis6/EntityID.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYID_H
-#define ENTITYID_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityInformationFamilyPdu.h
+++ b/src/dis6/EntityInformationFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYINFORMATIONFAMILYPDU_H
-#define ENTITYINFORMATIONFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityManagementFamilyPdu.h
+++ b/src/dis6/EntityManagementFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYMANAGEMENTFAMILYPDU_H
-#define ENTITYMANAGEMENTFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityStatePdu.h
+++ b/src/dis6/EntityStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYSTATEPDU_H
-#define ENTITYSTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityType.h>
@@ -127,7 +126,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityStateUpdatePdu.h
+++ b/src/dis6/EntityStateUpdatePdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYSTATEUPDATEPDU_H
-#define ENTITYSTATEUPDATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/Vector3Float.h>
@@ -89,7 +88,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EntityType.h
+++ b/src/dis6/EntityType.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYTYPE_H
-#define ENTITYTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Environment.h
+++ b/src/dis6/Environment.h
@@ -1,5 +1,4 @@
-#ifndef ENVIRONMENT_H
-#define ENVIRONMENT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EnvironmentalProcessPdu.h
+++ b/src/dis6/EnvironmentalProcessPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENVIRONMENTALPROCESSPDU_H
-#define ENVIRONMENTALPROCESSPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityType.h>
@@ -80,7 +79,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EventID.h
+++ b/src/dis6/EventID.h
@@ -1,5 +1,4 @@
-#ifndef EVENTID_H
-#define EVENTID_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EventReportPdu.h
+++ b/src/dis6/EventReportPdu.h
@@ -1,5 +1,4 @@
-#ifndef EVENTREPORTPDU_H
-#define EVENTREPORTPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/EventReportReliablePdu.h
+++ b/src/dis6/EventReportReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef EVENTREPORTRELIABLEPDU_H
-#define EVENTREPORTRELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FastEntityStatePdu.h
+++ b/src/dis6/FastEntityStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef FASTENTITYSTATEPDU_H
-#define FASTENTITYSTATEPDU_H
+#pragma once
 
 #include <dis6/ArticulationParameter.h>
 #include <vector>
@@ -272,7 +271,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FirePdu.h
+++ b/src/dis6/FirePdu.h
@@ -1,5 +1,4 @@
-#ifndef FIREPDU_H
-#define FIREPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
@@ -83,7 +82,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FixedDatum.h
+++ b/src/dis6/FixedDatum.h
@@ -1,5 +1,4 @@
-#ifndef FIXEDDATUM_H
-#define FIXEDDATUM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FourByteChunk.h
+++ b/src/dis6/FourByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef FOURBYTECHUNK_H
-#define FOURBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FundamentalParameterData.h
+++ b/src/dis6/FundamentalParameterData.h
@@ -1,5 +1,4 @@
-#ifndef FUNDAMENTALPARAMETERDATA_H
-#define FUNDAMENTALPARAMETERDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -91,7 +90,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/FundamentalParameterDataIff.h
+++ b/src/dis6/FundamentalParameterDataIff.h
@@ -1,5 +1,4 @@
-#ifndef FUNDAMENTALPARAMETERDATAIFF_H
-#define FUNDAMENTALPARAMETERDATAIFF_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -79,7 +78,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/GridAxisRecord.h
+++ b/src/dis6/GridAxisRecord.h
@@ -1,5 +1,4 @@
-#ifndef GRIDAXISRECORD_H
-#define GRIDAXISRECORD_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/GridAxisRecordRepresentation0.h
+++ b/src/dis6/GridAxisRecordRepresentation0.h
@@ -1,5 +1,4 @@
-#ifndef GRIDAXISRECORDREPRESENTATION0_H
-#define GRIDAXISRECORDREPRESENTATION0_H
+#pragma once
 
 #include <dis6/OneByteChunk.h>
 #include <vector>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/GridAxisRecordRepresentation1.h
+++ b/src/dis6/GridAxisRecordRepresentation1.h
@@ -1,5 +1,4 @@
-#ifndef GRIDAXISRECORDREPRESENTATION1_H
-#define GRIDAXISRECORDREPRESENTATION1_H
+#pragma once
 
 #include <dis6/TwoByteChunk.h>
 #include <vector>
@@ -58,7 +57,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/GridAxisRecordRepresentation2.h
+++ b/src/dis6/GridAxisRecordRepresentation2.h
@@ -1,5 +1,4 @@
-#ifndef GRIDAXISRECORDREPRESENTATION2_H
-#define GRIDAXISRECORDREPRESENTATION2_H
+#pragma once
 
 #include <dis6/FourByteChunk.h>
 #include <vector>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/GriddedDataPdu.h
+++ b/src/dis6/GriddedDataPdu.h
@@ -1,5 +1,4 @@
-#ifndef GRIDDEDDATAPDU_H
-#define GRIDDEDDATAPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityType.h>
@@ -130,7 +129,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IffAtcNavAidsLayer1Pdu.h
+++ b/src/dis6/IffAtcNavAidsLayer1Pdu.h
@@ -1,5 +1,4 @@
-#ifndef IFFATCNAVAIDSLAYER1PDU_H
-#define IFFATCNAVAIDSLAYER1PDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
@@ -78,7 +77,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IffAtcNavAidsLayer2Pdu.h
+++ b/src/dis6/IffAtcNavAidsLayer2Pdu.h
@@ -1,5 +1,4 @@
-#ifndef IFFATCNAVAIDSLAYER2PDU_H
-#define IFFATCNAVAIDSLAYER2PDU_H
+#pragma once
 
 #include <dis6/LayerHeader.h>
 #include <dis6/BeamData.h>
@@ -65,7 +64,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IffFundamentalData.h
+++ b/src/dis6/IffFundamentalData.h
@@ -1,5 +1,4 @@
-#ifndef IFFFUNDAMENTALDATA_H
-#define IFFFUNDAMENTALDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -91,7 +90,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IntercomCommunicationsParameters.h
+++ b/src/dis6/IntercomCommunicationsParameters.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMCOMMUNICATIONSPARAMETERS_H
-#define INTERCOMCOMMUNICATIONSPARAMETERS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IntercomControlPdu.h
+++ b/src/dis6/IntercomControlPdu.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMCONTROLPDU_H
-#define INTERCOMCONTROLPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -110,7 +109,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IntercomSignalPdu.h
+++ b/src/dis6/IntercomSignalPdu.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMSIGNALPDU_H
-#define INTERCOMSIGNALPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/OneByteChunk.h>
@@ -84,7 +83,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IsGroupOfPdu.h
+++ b/src/dis6/IsGroupOfPdu.h
@@ -1,5 +1,4 @@
-#ifndef ISGROUPOFPDU_H
-#define ISGROUPOFPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/VariableDatum.h>
@@ -78,7 +77,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/IsPartOfPdu.h
+++ b/src/dis6/IsPartOfPdu.h
@@ -1,5 +1,4 @@
-#ifndef ISPARTOFPDU_H
-#define ISPARTOFPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -80,7 +79,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/LayerHeader.h
+++ b/src/dis6/LayerHeader.h
@@ -1,5 +1,4 @@
-#ifndef LAYERHEADER_H
-#define LAYERHEADER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/LinearObjectStatePdu.h
+++ b/src/dis6/LinearObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef LINEAROBJECTSTATEPDU_H
-#define LINEAROBJECTSTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -98,7 +97,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/LinearSegmentParameter.h
+++ b/src/dis6/LinearSegmentParameter.h
@@ -1,5 +1,4 @@
-#ifndef LINEARSEGMENTPARAMETER_H
-#define LINEARSEGMENTPARAMETER_H
+#pragma once
 
 #include <dis6/SixByteChunk.h>
 #include <dis6/Vector3Double.h>
@@ -91,7 +90,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/LogisticsFamilyPdu.h
+++ b/src/dis6/LogisticsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef LOGISTICSFAMILYPDU_H
-#define LOGISTICSFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/LogisticsPdu.h
+++ b/src/dis6/LogisticsPdu.h
@@ -1,5 +1,4 @@
-#ifndef LOGISTICSPDU_H
-#define LOGISTICSPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -34,4 +33,3 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif

--- a/src/dis6/Marking.h
+++ b/src/dis6/Marking.h
@@ -1,5 +1,4 @@
-#ifndef MARKING_H
-#define MARKING_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/MinefieldDataPdu.h
+++ b/src/dis6/MinefieldDataPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDDATAPDU_H
-#define MINEFIELDDATAPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -125,7 +124,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/MinefieldFamilyPdu.h
+++ b/src/dis6/MinefieldFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDFAMILYPDU_H
-#define MINEFIELDFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/MinefieldPduFamily.h
+++ b/src/dis6/MinefieldPduFamily.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDPDUFAMILY_H
-#define MINEFIELDPDUFAMILY_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -34,4 +33,3 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif

--- a/src/dis6/MinefieldQueryPdu.h
+++ b/src/dis6/MinefieldQueryPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDQUERYPDU_H
-#define MINEFIELDQUERYPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -101,7 +100,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/MinefieldResponseNackPdu.h
+++ b/src/dis6/MinefieldResponseNackPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDRESPONSENACKPDU_H
-#define MINEFIELDRESPONSENACKPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -68,7 +67,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/MinefieldStatePdu.h
+++ b/src/dis6/MinefieldStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDSTATEPDU_H
-#define MINEFIELDSTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityType.h>
@@ -115,7 +114,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ModulationType.h
+++ b/src/dis6/ModulationType.h
@@ -1,5 +1,4 @@
-#ifndef MODULATIONTYPE_H
-#define MODULATIONTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/NamedLocation.h
+++ b/src/dis6/NamedLocation.h
@@ -1,5 +1,4 @@
-#ifndef NAMEDLOCATION_H
-#define NAMEDLOCATION_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ObjectType.h
+++ b/src/dis6/ObjectType.h
@@ -1,5 +1,4 @@
-#ifndef OBJECTTYPE_H
-#define OBJECTTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/OneByteChunk.h
+++ b/src/dis6/OneByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef ONEBYTECHUNK_H
-#define ONEBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Orientation.h
+++ b/src/dis6/Orientation.h
@@ -1,5 +1,4 @@
-#ifndef ORIENTATION_H
-#define ORIENTATION_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Pdu.h
+++ b/src/dis6/Pdu.h
@@ -1,5 +1,4 @@
-#ifndef PDU_H
-#define PDU_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/PduContainer.h
+++ b/src/dis6/PduContainer.h
@@ -1,5 +1,4 @@
-#ifndef PDUCONTAINER_H
-#define PDUCONTAINER_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <vector>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Point.h
+++ b/src/dis6/Point.h
@@ -1,5 +1,4 @@
-#ifndef POINT_H
-#define POINT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/PointObjectStatePdu.h
+++ b/src/dis6/PointObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef POINTOBJECTSTATEPDU_H
-#define POINTOBJECTSTATEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -118,7 +117,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/PropulsionSystemData.h
+++ b/src/dis6/PropulsionSystemData.h
@@ -1,5 +1,4 @@
-#ifndef PROPULSIONSYSTEMDATA_H
-#define PROPULSIONSYSTEMDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RadioCommunicationsFamilyPdu.h
+++ b/src/dis6/RadioCommunicationsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef RADIOCOMMUNICATIONSFAMILYPDU_H
-#define RADIOCOMMUNICATIONSFAMILYPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/Pdu.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RadioEntityType.h
+++ b/src/dis6/RadioEntityType.h
@@ -1,5 +1,4 @@
-#ifndef RADIOENTITYTYPE_H
-#define RADIOENTITYTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -66,7 +65,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ReceiverPdu.h
+++ b/src/dis6/ReceiverPdu.h
@@ -1,5 +1,4 @@
-#ifndef RECEIVERPDU_H
-#define RECEIVERPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/RadioCommunicationsFamilyPdu.h>
@@ -64,7 +63,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RecordQueryReliablePdu.h
+++ b/src/dis6/RecordQueryReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef RECORDQUERYRELIABLEPDU_H
-#define RECORDQUERYRELIABLEPDU_H
+#pragma once
 
 #include <dis6/FourByteChunk.h>
 #include <vector>
@@ -82,7 +81,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RecordSet.h
+++ b/src/dis6/RecordSet.h
@@ -1,5 +1,4 @@
-#ifndef RECORDSET_H
-#define RECORDSET_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Relationship.h
+++ b/src/dis6/Relationship.h
@@ -1,5 +1,4 @@
-#ifndef RELATIONSHIP_H
-#define RELATIONSHIP_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RemoveEntityPdu.h
+++ b/src/dis6/RemoveEntityPdu.h
@@ -1,5 +1,4 @@
-#ifndef REMOVEENTITYPDU_H
-#define REMOVEENTITYPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RemoveEntityReliablePdu.h
+++ b/src/dis6/RemoveEntityReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef REMOVEENTITYRELIABLEPDU_H
-#define REMOVEENTITYRELIABLEPDU_H
+#pragma once
 
 #include <dis6/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -56,7 +55,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RepairCompletePdu.h
+++ b/src/dis6/RepairCompletePdu.h
@@ -1,5 +1,4 @@
-#ifndef REPAIRCOMPLETEPDU_H
-#define REPAIRCOMPLETEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -60,7 +59,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/RepairResponsePdu.h
+++ b/src/dis6/RepairResponsePdu.h
@@ -1,5 +1,4 @@
-#ifndef REPAIRRESPONSEPDU_H
-#define REPAIRRESPONSEPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -66,7 +65,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ResupplyCancelPdu.h
+++ b/src/dis6/ResupplyCancelPdu.h
@@ -1,5 +1,4 @@
-#ifndef RESUPPLYCANCELPDU_H
-#define RESUPPLYCANCELPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ResupplyOfferPdu.h
+++ b/src/dis6/ResupplyOfferPdu.h
@@ -1,5 +1,4 @@
-#ifndef RESUPPLYOFFERPDU_H
-#define RESUPPLYOFFERPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ResupplyReceivedPdu.h
+++ b/src/dis6/ResupplyReceivedPdu.h
@@ -1,5 +1,4 @@
-#ifndef RESUPPLYRECEIVEDPDU_H
-#define RESUPPLYRECEIVEDPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SeesPdu.h
+++ b/src/dis6/SeesPdu.h
@@ -1,5 +1,4 @@
-#ifndef SEESPDU_H
-#define SEESPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/PropulsionSystemData.h>
@@ -85,7 +84,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ServiceRequestPdu.h
+++ b/src/dis6/ServiceRequestPdu.h
@@ -1,5 +1,4 @@
-#ifndef SERVICEREQUESTPDU_H
-#define SERVICEREQUESTPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SetDataPdu.h
+++ b/src/dis6/SetDataPdu.h
@@ -1,5 +1,4 @@
-#ifndef SETDATAPDU_H
-#define SETDATAPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SetDataReliablePdu.h
+++ b/src/dis6/SetDataReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef SETDATARELIABLEPDU_H
-#define SETDATARELIABLEPDU_H
+#pragma once
 
 #include <dis6/FixedDatum.h>
 #include <dis6/VariableDatum.h>
@@ -83,7 +82,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SetRecordReliablePdu.h
+++ b/src/dis6/SetRecordReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef SETRECORDRELIABLEPDU_H
-#define SETRECORDRELIABLEPDU_H
+#pragma once
 
 #include <dis6/RecordSet.h>
 #include <vector>
@@ -70,7 +69,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/ShaftRPMs.h
+++ b/src/dis6/ShaftRPMs.h
@@ -1,5 +1,4 @@
-#ifndef SHAFTRPMS_H
-#define SHAFTRPMS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SignalPdu.h
+++ b/src/dis6/SignalPdu.h
@@ -1,5 +1,4 @@
-#ifndef SIGNALPDU_H
-#define SIGNALPDU_H
+#pragma once
 
 #include <dis6/OneByteChunk.h>
 #include <vector>
@@ -70,7 +69,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SimulationAddress.h
+++ b/src/dis6/SimulationAddress.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONADDRESS_H
-#define SIMULATIONADDRESS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SimulationManagementFamilyPdu.h
+++ b/src/dis6/SimulationManagementFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONMANAGEMENTFAMILYPDU_H
-#define SIMULATIONMANAGEMENTFAMILYPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SimulationManagementWithReliabilityFamilyPdu.h
+++ b/src/dis6/SimulationManagementWithReliabilityFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONMANAGEMENTWITHRELIABILITYFAMILYPDU_H
-#define SIMULATIONMANAGEMENTWITHRELIABILITYFAMILYPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SixByteChunk.h
+++ b/src/dis6/SixByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef SIXBYTECHUNK_H
-#define SIXBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SphericalHarmonicAntennaPattern.h
+++ b/src/dis6/SphericalHarmonicAntennaPattern.h
@@ -1,5 +1,4 @@
-#ifndef SPHERICALHARMONICANTENNAPATTERN_H
-#define SPHERICALHARMONICANTENNAPATTERN_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -36,7 +35,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/StartResumePdu.h
+++ b/src/dis6/StartResumePdu.h
@@ -1,5 +1,4 @@
-#ifndef STARTRESUMEPDU_H
-#define STARTRESUMEPDU_H
+#pragma once
 
 #include <dis6/ClockTime.h>
 #include <dis6/ClockTime.h>
@@ -54,7 +53,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/StartResumeReliablePdu.h
+++ b/src/dis6/StartResumeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef STARTRESUMERELIABLEPDU_H
-#define STARTRESUMERELIABLEPDU_H
+#pragma once
 
 #include <dis6/ClockTime.h>
 #include <dis6/ClockTime.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/StopFreezePdu.h
+++ b/src/dis6/StopFreezePdu.h
@@ -1,5 +1,4 @@
-#ifndef STOPFREEZEPDU_H
-#define STOPFREEZEPDU_H
+#pragma once
 
 #include <dis6/ClockTime.h>
 #include <dis6/SimulationManagementFamilyPdu.h>
@@ -64,7 +63,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/StopFreezeReliablePdu.h
+++ b/src/dis6/StopFreezeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef STOPFREEZERELIABLEPDU_H
-#define STOPFREEZERELIABLEPDU_H
+#pragma once
 
 #include <dis6/ClockTime.h>
 #include <dis6/SimulationManagementWithReliabilityFamilyPdu.h>
@@ -70,7 +69,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SupplyQuantity.h
+++ b/src/dis6/SupplyQuantity.h
@@ -1,5 +1,4 @@
-#ifndef SUPPLYQUANTITY_H
-#define SUPPLYQUANTITY_H
+#pragma once
 
 #include <dis6/EntityType.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SyntheticEnvironmentFamilyPdu.h
+++ b/src/dis6/SyntheticEnvironmentFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SYNTHETICENVIRONMENTFAMILYPDU_H
-#define SYNTHETICENVIRONMENTFAMILYPDU_H
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/SystemID.h
+++ b/src/dis6/SystemID.h
@@ -1,5 +1,4 @@
-#ifndef SYSTEMID_H
-#define SYSTEMID_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/TrackJamTarget.h
+++ b/src/dis6/TrackJamTarget.h
@@ -1,5 +1,4 @@
-#ifndef TRACKJAMTARGET_H
-#define TRACKJAMTARGET_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <utils/DataStream.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/TransferControlRequestPdu.h
+++ b/src/dis6/TransferControlRequestPdu.h
@@ -1,5 +1,4 @@
-#ifndef TRANSFERCONTROLREQUESTPDU_H
-#define TRANSFERCONTROLREQUESTPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -88,7 +87,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/TransmitterPdu.h
+++ b/src/dis6/TransmitterPdu.h
@@ -1,5 +1,4 @@
-#ifndef TRANSMITTERPDU_H
-#define TRANSMITTERPDU_H
+#pragma once
 
 #include <dis6/RadioEntityType.h>
 #include <dis6/Vector3Double.h>
@@ -157,7 +156,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/TwoByteChunk.h
+++ b/src/dis6/TwoByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef TWOBYTECHUNK_H
-#define TWOBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/UaPdu.h
+++ b/src/dis6/UaPdu.h
@@ -1,5 +1,4 @@
-#ifndef UAPDU_H
-#define UAPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EventID.h>
@@ -111,7 +110,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/VariableDatum.h
+++ b/src/dis6/VariableDatum.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLEDATUM_H
-#define VARIABLEDATUM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -54,7 +53,6 @@ virtual unsigned int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Vector3Double.h
+++ b/src/dis6/Vector3Double.h
@@ -1,5 +1,4 @@
-#ifndef VECTOR3DOUBLE_H
-#define VECTOR3DOUBLE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/Vector3Float.h
+++ b/src/dis6/Vector3Float.h
@@ -1,5 +1,4 @@
-#ifndef VECTOR3FLOAT_H
-#define VECTOR3FLOAT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/VectoringNozzleSystemData.h
+++ b/src/dis6/VectoringNozzleSystemData.h
@@ -1,5 +1,4 @@
-#ifndef VECTORINGNOZZLESYSTEMDATA_H
-#define VECTORINGNOZZLESYSTEMDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis6/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/WarfareFamilyPdu.h
+++ b/src/dis6/WarfareFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef WARFAREFAMILYPDU_H
-#define WARFAREFAMILYPDU_H
+#pragma once
 
 #include <dis6/EntityID.h>
 #include <dis6/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis6/msLibMacro.h
+++ b/src/dis6/msLibMacro.h
@@ -1,5 +1,4 @@
-#ifndef MSLIBMACRO_H
-#define MSLIBMACRO_H
+#pragma once
 #if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__) || defined( __BCPLUSPLUS__)  || defined( __MWERKS__)
 #  ifdef EXPORT_LIBRARY
 #    define EXPORT_MACRO __declspec(dllexport)
@@ -8,5 +7,4 @@
 #  endif
 #else
 #  define EXPORT_MACRO
-#endif
 #endif

--- a/src/dis6/symbolic_names.h
+++ b/src/dis6/symbolic_names.h
@@ -1,5 +1,4 @@
-#ifndef SYMBOLIC_NAMES_H_INCLUDED
-#define SYMBOLIC_NAMES_H_INCLUDED
+#pragma once_INCLUDED
 
 #include <dis6/EntityID.h>
 
@@ -93,4 +92,3 @@ const DIS::EntityID TARGET_ID_UNKNOWN(NO_SITE, NO_APPLIC, NO_ENTITY);
 */
 }
 
-#endif // SYMBOLIC_NAMES_H_INCLUDED

--- a/src/dis7/AcknowledgePdu.h
+++ b/src/dis7/AcknowledgePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACKNOWLEDGEPDU_H
-#define ACKNOWLEDGEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -66,7 +65,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AcknowledgeReliablePdu.h
+++ b/src/dis7/AcknowledgeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACKNOWLEDGERELIABLEPDU_H
-#define ACKNOWLEDGERELIABLEPDU_H
+#pragma once
 
 #include <dis7/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -50,7 +49,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AcousticEmitter.h
+++ b/src/dis7/AcousticEmitter.h
@@ -1,5 +1,4 @@
-#ifndef ACOUSTICEMITTER_H
-#define ACOUSTICEMITTER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ActionRequestPdu.h
+++ b/src/dis7/ActionRequestPdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONREQUESTPDU_H
-#define ACTIONREQUESTPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -87,7 +86,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ActionRequestReliablePdu.h
+++ b/src/dis7/ActionRequestReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONREQUESTRELIABLEPDU_H
-#define ACTIONREQUESTRELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -89,7 +88,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ActionResponsePdu.h
+++ b/src/dis7/ActionResponsePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONRESPONSEPDU_H
-#define ACTIONRESPONSEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -87,7 +86,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ActionResponseReliablePdu.h
+++ b/src/dis7/ActionResponseReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef ACTIONRESPONSERELIABLEPDU_H
-#define ACTIONRESPONSERELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AggregateIdentifier.h
+++ b/src/dis7/AggregateIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATEIDENTIFIER_H
-#define AGGREGATEIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AggregateMarking.h
+++ b/src/dis7/AggregateMarking.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATEMARKING_H
-#define AGGREGATEMARKING_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AggregateType.h
+++ b/src/dis7/AggregateType.h
@@ -1,5 +1,4 @@
-#ifndef AGGREGATETYPE_H
-#define AGGREGATETYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AngleDeception.h
+++ b/src/dis7/AngleDeception.h
@@ -1,5 +1,4 @@
-#ifndef ANGLEDECEPTION_H
-#define ANGLEDECEPTION_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -111,7 +110,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AngularVelocityVector.h
+++ b/src/dis7/AngularVelocityVector.h
@@ -1,5 +1,4 @@
-#ifndef ANGULARVELOCITYVECTOR_H
-#define ANGULARVELOCITYVECTOR_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AntennaLocation.h
+++ b/src/dis7/AntennaLocation.h
@@ -1,5 +1,4 @@
-#ifndef ANTENNALOCATION_H
-#define ANTENNALOCATION_H
+#pragma once
 
 #include <dis7/Vector3Double.h>
 #include <dis7/Vector3Float.h>
@@ -47,7 +46,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ArealObjectStatePdu.h
+++ b/src/dis7/ArealObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef AREALOBJECTSTATEPDU_H
-#define AREALOBJECTSTATEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -116,7 +115,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ArticulatedParts.h
+++ b/src/dis7/ArticulatedParts.h
@@ -1,5 +1,4 @@
-#ifndef ARTICULATEDPARTS_H
-#define ARTICULATEDPARTS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -65,7 +64,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Association.h
+++ b/src/dis7/Association.h
@@ -1,5 +1,4 @@
-#ifndef ASSOCIATION_H
-#define ASSOCIATION_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/Vector3Double.h>
@@ -57,7 +56,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AttachedParts.h
+++ b/src/dis7/AttachedParts.h
@@ -1,5 +1,4 @@
-#ifndef ATTACHEDPARTS_H
-#define ATTACHEDPARTS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Attribute.h
+++ b/src/dis7/Attribute.h
@@ -1,5 +1,4 @@
-#ifndef ATTRIBUTE_H
-#define ATTRIBUTE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/AttributePdu.h
+++ b/src/dis7/AttributePdu.h
@@ -1,5 +1,4 @@
-#ifndef ATTRIBUTEPDU_H
-#define ATTRIBUTEPDU_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <dis7/EntityInformationFamilyPdu.h>
@@ -88,7 +87,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/BeamAntennaPattern.h
+++ b/src/dis7/BeamAntennaPattern.h
@@ -1,5 +1,4 @@
-#ifndef BEAMANTENNAPATTERN_H
-#define BEAMANTENNAPATTERN_H
+#pragma once
 
 #include <dis7/EulerAngles.h>
 #include <utils/DataStream.h>
@@ -88,7 +87,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/BeamData.h
+++ b/src/dis7/BeamData.h
@@ -1,5 +1,4 @@
-#ifndef BEAMDATA_H
-#define BEAMDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/BeamStatus.h
+++ b/src/dis7/BeamStatus.h
@@ -1,5 +1,4 @@
-#ifndef BEAMSTATUS_H
-#define BEAMSTATUS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -37,7 +36,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/BlankingSector.h
+++ b/src/dis7/BlankingSector.h
@@ -1,5 +1,4 @@
-#ifndef BLANKINGSECTOR_H
-#define BLANKINGSECTOR_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -81,7 +80,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ChangeOptions.h
+++ b/src/dis7/ChangeOptions.h
@@ -1,5 +1,4 @@
-#ifndef CHANGEOPTIONS_H
-#define CHANGEOPTIONS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -31,7 +30,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ClockTime.h
+++ b/src/dis7/ClockTime.h
@@ -1,5 +1,4 @@
-#ifndef CLOCKTIME_H
-#define CLOCKTIME_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CollisionElasticPdu.h
+++ b/src/dis7/CollisionElasticPdu.h
@@ -1,5 +1,4 @@
-#ifndef COLLISIONELASTICPDU_H
-#define COLLISIONELASTICPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -134,7 +133,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CollisionPdu.h
+++ b/src/dis7/CollisionPdu.h
@@ -1,5 +1,4 @@
-#ifndef COLLISIONPDU_H
-#define COLLISIONPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -90,7 +89,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CommentPdu.h
+++ b/src/dis7/CommentPdu.h
@@ -1,5 +1,4 @@
-#ifndef COMMENTPDU_H
-#define COMMENTPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -59,7 +58,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CommentReliablePdu.h
+++ b/src/dis7/CommentReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef COMMENTRELIABLEPDU_H
-#define COMMENTRELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -59,7 +58,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CommunicationsNodeID.h
+++ b/src/dis7/CommunicationsNodeID.h
@@ -1,5 +1,4 @@
-#ifndef COMMUNICATIONSNODEID_H
-#define COMMUNICATIONSNODEID_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CreateEntityPdu.h
+++ b/src/dis7/CreateEntityPdu.h
@@ -1,5 +1,4 @@
-#ifndef CREATEENTITYPDU_H
-#define CREATEENTITYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -54,7 +53,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/CreateEntityReliablePdu.h
+++ b/src/dis7/CreateEntityReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef CREATEENTITYRELIABLEPDU_H
-#define CREATEENTITYRELIABLEPDU_H
+#pragma once
 
 #include <dis7/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -56,7 +55,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DataPdu.h
+++ b/src/dis7/DataPdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAPDU_H
-#define DATAPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DataQueryDatumSpecification.h
+++ b/src/dis7/DataQueryDatumSpecification.h
@@ -1,5 +1,4 @@
-#ifndef DATAQUERYDATUMSPECIFICATION_H
-#define DATAQUERYDATUMSPECIFICATION_H
+#pragma once
 
 #include <dis7/UnsignedDISInteger.h>
 #include <dis7/UnsignedDISInteger.h>
@@ -58,7 +57,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DataQueryPdu.h
+++ b/src/dis7/DataQueryPdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAQUERYPDU_H
-#define DATAQUERYPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DataQueryReliablePdu.h
+++ b/src/dis7/DataQueryReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef DATAQUERYRELIABLEPDU_H
-#define DATAQUERYRELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -89,7 +88,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DataReliablePdu.h
+++ b/src/dis7/DataReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef DATARELIABLEPDU_H
-#define DATARELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -83,7 +82,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DatumSpecification.h
+++ b/src/dis7/DatumSpecification.h
@@ -1,5 +1,4 @@
-#ifndef DATUMSPECIFICATION_H
-#define DATUMSPECIFICATION_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -58,7 +57,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DeadReckoningParameters.h
+++ b/src/dis7/DeadReckoningParameters.h
@@ -1,5 +1,4 @@
-#ifndef DEADRECKONINGPARAMETERS_H
-#define DEADRECKONINGPARAMETERS_H
+#pragma once
 
 #include <dis7/Vector3Float.h>
 #include <dis7/Vector3Float.h>
@@ -60,7 +59,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DesignatorPdu.h
+++ b/src/dis7/DesignatorPdu.h
@@ -1,5 +1,4 @@
-#ifndef DESIGNATORPDU_H
-#define DESIGNATORPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -114,7 +113,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DetonationPdu.h
+++ b/src/dis7/DetonationPdu.h
@@ -1,5 +1,4 @@
-#ifndef DETONATIONPDU_H
-#define DETONATIONPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EventIdentifier.h>
@@ -106,7 +105,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DirectedEnergyAreaAimpoint.h
+++ b/src/dis7/DirectedEnergyAreaAimpoint.h
@@ -1,5 +1,4 @@
-#ifndef DIRECTEDENERGYAREAAIMPOINT_H
-#define DIRECTEDENERGYAREAAIMPOINT_H
+#pragma once
 
 #include <dis7/BeamAntennaPattern.h>
 #include <dis7/DirectedEnergyTargetEnergyDeposition.h>
@@ -76,7 +75,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DirectedEnergyDamage.h
+++ b/src/dis7/DirectedEnergyDamage.h
@@ -1,5 +1,4 @@
-#ifndef DIRECTEDENERGYDAMAGE_H
-#define DIRECTEDENERGYDAMAGE_H
+#pragma once
 
 #include <dis7/Vector3Float.h>
 #include <dis7/EventIdentifier.h>
@@ -107,7 +106,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DirectedEnergyFirePdu.h
+++ b/src/dis7/DirectedEnergyFirePdu.h
@@ -1,5 +1,4 @@
-#ifndef DIRECTEDENERGYFIREPDU_H
-#define DIRECTEDENERGYFIREPDU_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <dis7/ClockTime.h>
@@ -136,7 +135,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DirectedEnergyPrecisionAimpoint.h
+++ b/src/dis7/DirectedEnergyPrecisionAimpoint.h
@@ -1,5 +1,4 @@
-#ifndef DIRECTEDENERGYPRECISIONAIMPOINT_H
-#define DIRECTEDENERGYPRECISIONAIMPOINT_H
+#pragma once
 
 #include <dis7/Vector3Double.h>
 #include <dis7/Vector3Float.h>
@@ -119,7 +118,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DirectedEnergyTargetEnergyDeposition.h
+++ b/src/dis7/DirectedEnergyTargetEnergyDeposition.h
@@ -1,5 +1,4 @@
-#ifndef DIRECTEDENERGYTARGETENERGYDEPOSITION_H
-#define DIRECTEDENERGYTARGETENERGYDEPOSITION_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/DistributedEmissionsFamilyPdu.h
+++ b/src/dis7/DistributedEmissionsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef DISTRIBUTEDEMISSIONSFAMILYPDU_H
-#define DISTRIBUTEDEMISSIONSFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EEFundamentalParameterData.h
+++ b/src/dis7/EEFundamentalParameterData.h
@@ -1,5 +1,4 @@
-#ifndef EEFUNDAMENTALPARAMETERDATA_H
-#define EEFUNDAMENTALPARAMETERDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EightByteChunk.h
+++ b/src/dis7/EightByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef EIGHTBYTECHUNK_H
-#define EIGHTBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ElectromagneticEmissionsPdu.h
+++ b/src/dis7/ElectromagneticEmissionsPdu.h
@@ -1,5 +1,4 @@
-#ifndef ELECTRONICEMISSIONSPDU_H
-#define ELECTRONICEMISSIONSPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EventIdentifier.h>
@@ -102,7 +101,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EmitterSystem.h
+++ b/src/dis7/EmitterSystem.h
@@ -1,5 +1,4 @@
-#ifndef EMITTERSYSTEM_H
-#define EMITTERSYSTEM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EngineFuel.h
+++ b/src/dis7/EngineFuel.h
@@ -1,5 +1,4 @@
-#ifndef ENGINEFUEL_H
-#define ENGINEFUEL_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EngineFuelReload.h
+++ b/src/dis7/EngineFuelReload.h
@@ -1,5 +1,4 @@
-#ifndef ENGINEFUELRELOAD_H
-#define ENGINEFUELRELOAD_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityAssociation.h
+++ b/src/dis7/EntityAssociation.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYASSOCIATION_H
-#define ENTITYASSOCIATION_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -87,7 +86,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityDamageStatusPdu.h
+++ b/src/dis7/EntityDamageStatusPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYDAMAGESTATUSPDU_H
-#define ENTITYDAMAGESTATUSPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/DirectedEnergyDamage.h>
@@ -66,7 +65,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityID.h
+++ b/src/dis7/EntityID.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYID_H
-#define ENTITYID_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityInformationFamilyPdu.h
+++ b/src/dis7/EntityInformationFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYINFORMATIONFAMILYPDU_H
-#define ENTITYINFORMATIONFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityManagementFamilyPdu.h
+++ b/src/dis7/EntityManagementFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYMANAGEMENTFAMILYPDU_H
-#define ENTITYMANAGEMENTFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityMarking.h
+++ b/src/dis7/EntityMarking.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYMARKING_H
-#define ENTITYMARKING_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityStatePdu.h
+++ b/src/dis7/EntityStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYSTATEPDU_H
-#define ENTITYSTATEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityType.h>
@@ -127,7 +126,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityStateUpdatePdu.h
+++ b/src/dis7/EntityStateUpdatePdu.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYSTATEUPDATEPDU_H
-#define ENTITYSTATEUPDATEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/Vector3Float.h>
@@ -90,7 +89,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityType.h
+++ b/src/dis7/EntityType.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYTYPE_H
-#define ENTITYTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EntityTypeVP.h
+++ b/src/dis7/EntityTypeVP.h
@@ -1,5 +1,4 @@
-#ifndef ENTITYTYPEVP_H
-#define ENTITYTYPEVP_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -63,7 +62,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Environment.h
+++ b/src/dis7/Environment.h
@@ -1,5 +1,4 @@
-#ifndef ENVIRONMENT_H
-#define ENVIRONMENT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EnvironmentGeneral.h
+++ b/src/dis7/EnvironmentGeneral.h
@@ -1,5 +1,4 @@
-#ifndef ENVIRONMENTGENERAL_H
-#define ENVIRONMENTGENERAL_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EnvironmentType.h
+++ b/src/dis7/EnvironmentType.h
@@ -1,5 +1,4 @@
-#ifndef ENVIRONMENTTYPE_H
-#define ENVIRONMENTTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EulerAngles.h
+++ b/src/dis7/EulerAngles.h
@@ -1,5 +1,4 @@
-#ifndef EULERANGLES_H
-#define EULERANGLES_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EventIdentifier.h
+++ b/src/dis7/EventIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef EVENTIDENTIFIER_H
-#define EVENTIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EventIdentifierLiveEntity.h
+++ b/src/dis7/EventIdentifierLiveEntity.h
@@ -1,5 +1,4 @@
-#ifndef EVENTIDENTIFIERLIVEENTITY_H
-#define EVENTIDENTIFIERLIVEENTITY_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EventReportPdu.h
+++ b/src/dis7/EventReportPdu.h
@@ -1,5 +1,4 @@
-#ifndef EVENTREPORTPDU_H
-#define EVENTREPORTPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/EventReportReliablePdu.h
+++ b/src/dis7/EventReportReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef EVENTREPORTRELIABLEPDU_H
-#define EVENTREPORTRELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Expendable.h
+++ b/src/dis7/Expendable.h
@@ -1,5 +1,4 @@
-#ifndef EXPENDABLE_H
-#define EXPENDABLE_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -59,7 +58,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ExpendableDescriptor.h
+++ b/src/dis7/ExpendableDescriptor.h
@@ -1,5 +1,4 @@
-#ifndef EXPENDABLEDESCRIPTOR_H
-#define EXPENDABLEDESCRIPTOR_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ExpendableReload.h
+++ b/src/dis7/ExpendableReload.h
@@ -1,5 +1,4 @@
-#ifndef EXPENDABLERELOAD_H
-#define EXPENDABLERELOAD_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -64,7 +63,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ExplosionDescriptor.h
+++ b/src/dis7/ExplosionDescriptor.h
@@ -1,5 +1,4 @@
-#ifndef EXPLOSIONDESCRIPTOR_H
-#define EXPLOSIONDESCRIPTOR_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -57,7 +56,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FalseTargetsAttribute.h
+++ b/src/dis7/FalseTargetsAttribute.h
@@ -1,5 +1,4 @@
-#ifndef FALSETARGETSATTRIBUTE_H
-#define FALSETARGETSATTRIBUTE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -101,7 +100,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FastEntityStatePdu.h
+++ b/src/dis7/FastEntityStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef FASTENTITYSTATEPDU_H
-#define FASTENTITYSTATEPDU_H
+#pragma once
 
 #include <dis7/VariableParameter.h>
 #include <vector>
@@ -272,7 +271,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FirePdu.h
+++ b/src/dis7/FirePdu.h
@@ -1,5 +1,4 @@
-#ifndef FIREPDU_H
-#define FIREPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EventIdentifier.h>
@@ -84,7 +83,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FixedDatum.h
+++ b/src/dis7/FixedDatum.h
@@ -1,5 +1,4 @@
-#ifndef FIXEDDATUM_H
-#define FIXEDDATUM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FourByteChunk.h
+++ b/src/dis7/FourByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef FOURBYTECHUNK_H
-#define FOURBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/FundamentalOperationalData.h
+++ b/src/dis7/FundamentalOperationalData.h
@@ -1,5 +1,4 @@
-#ifndef FUNDAMENTALOPERATIONALDATA_H
-#define FUNDAMENTALOPERATIONALDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -91,7 +90,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/GridAxis.h
+++ b/src/dis7/GridAxis.h
@@ -1,5 +1,4 @@
-#ifndef GRIDAXIS_H
-#define GRIDAXIS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/GroupIdentifier.h
+++ b/src/dis7/GroupIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef GROUPIDENTIFIER_H
-#define GROUPIDENTIFIER_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IFFFundamentalParameterData.h
+++ b/src/dis7/IFFFundamentalParameterData.h
@@ -1,5 +1,4 @@
-#ifndef IFFFUNDAMENTALPARAMETERDATA_H
-#define IFFFUNDAMENTALPARAMETERDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -74,7 +73,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IFFPdu.h
+++ b/src/dis7/IFFPdu.h
@@ -1,5 +1,4 @@
-#ifndef IFFPDU_H
-#define IFFPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EventIdentifier.h>
@@ -112,4 +111,3 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif

--- a/src/dis7/IOCommunicationsNode.h
+++ b/src/dis7/IOCommunicationsNode.h
@@ -1,5 +1,4 @@
-#ifndef IOCOMMUNICATIONSNODE_H
-#define IOCOMMUNICATIONSNODE_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -63,7 +62,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IOEffect.h
+++ b/src/dis7/IOEffect.h
@@ -1,5 +1,4 @@
-#ifndef IOEFFECT_H
-#define IOEFFECT_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -78,7 +77,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IffDataSpecification.h
+++ b/src/dis7/IffDataSpecification.h
@@ -1,5 +1,4 @@
-#ifndef IFFDATASPECIFICATION_H
-#define IFFDATASPECIFICATION_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -39,7 +38,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IntercomCommunicationsParameters.h
+++ b/src/dis7/IntercomCommunicationsParameters.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMCOMMUNICATIONSPARAMETERS_H
-#define INTERCOMCOMMUNICATIONSPARAMETERS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IntercomIdentifier.h
+++ b/src/dis7/IntercomIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMIDENTIFIER_H
-#define INTERCOMIDENTIFIER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IntercomSignalPdu.h
+++ b/src/dis7/IntercomSignalPdu.h
@@ -1,5 +1,4 @@
-#ifndef INTERCOMSIGNALPDU_H
-#define INTERCOMSIGNALPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/OneByteChunk.h>
@@ -84,7 +83,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/IsPartOfPdu.h
+++ b/src/dis7/IsPartOfPdu.h
@@ -1,5 +1,4 @@
-#ifndef ISPARTOFPDU_H
-#define ISPARTOFPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -80,7 +79,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/JammingTechnique.h
+++ b/src/dis7/JammingTechnique.h
@@ -1,5 +1,4 @@
-#ifndef JAMMINGTECHNIQUE_H
-#define JAMMINGTECHNIQUE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LaunchedMunitionRecord.h
+++ b/src/dis7/LaunchedMunitionRecord.h
@@ -1,5 +1,4 @@
-#ifndef LAUNCHEDMUNITIONRECORD_H
-#define LAUNCHEDMUNITIONRECORD_H
+#pragma once
 
 #include <dis7/EventIdentifier.h>
 #include <dis7/EventIdentifier.h>
@@ -74,7 +73,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LayerHeader.h
+++ b/src/dis7/LayerHeader.h
@@ -1,5 +1,4 @@
-#ifndef LAYERHEADER_H
-#define LAYERHEADER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LinearObjectStatePdu.h
+++ b/src/dis7/LinearObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef LINEAROBJECTSTATEPDU_H
-#define LINEAROBJECTSTATEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -98,7 +97,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LinearSegmentParameter.h
+++ b/src/dis7/LinearSegmentParameter.h
@@ -1,5 +1,4 @@
-#ifndef LINEARSEGMENTPARAMETER_H
-#define LINEARSEGMENTPARAMETER_H
+#pragma once
 
 #include <dis7/Vector3Double.h>
 #include <dis7/EulerAngles.h>
@@ -95,7 +94,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LiveEntityIdentifier.h
+++ b/src/dis7/LiveEntityIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef LIVEENTITYIDENTIFIER_H
-#define LIVEENTITYIDENTIFIER_H
+#pragma once
 
 #include <dis7/LiveSimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LiveEntityPdu.h
+++ b/src/dis7/LiveEntityPdu.h
@@ -1,5 +1,4 @@
-#ifndef LIVEENTITYPDU_H
-#define LIVEENTITYPDU_H
+#pragma once
 
 #include <dis7/PduSuperclass.h>
 #include <utils/DataStream.h>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LiveSimulationAddress.h
+++ b/src/dis7/LiveSimulationAddress.h
@@ -1,5 +1,4 @@
-#ifndef LIVESIMULATIONADDRESS_H
-#define LIVESIMULATIONADDRESS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/LogisticsFamilyPdu.h
+++ b/src/dis7/LogisticsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef LOGISTICSFAMILYPDU_H
-#define LOGISTICSFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MineEntityIdentifier.h
+++ b/src/dis7/MineEntityIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef MINEENTITYIDENTIFIER_H
-#define MINEENTITYIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MinefieldFamilyPdu.h
+++ b/src/dis7/MinefieldFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDFAMILYPDU_H
-#define MINEFIELDFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MinefieldIdentifier.h
+++ b/src/dis7/MinefieldIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDIDENTIFIER_H
-#define MINEFIELDIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MinefieldResponseNackPdu.h
+++ b/src/dis7/MinefieldResponseNackPdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDRESPONSENACKPDU_H
-#define MINEFIELDRESPONSENACKPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -68,7 +67,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MinefieldStatePdu.h
+++ b/src/dis7/MinefieldStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef MINEFIELDSTATEPDU_H
-#define MINEFIELDSTATEPDU_H
+#pragma once
 
 #include <dis7/MinefieldIdentifier.h>
 #include <dis7/EntityType.h>
@@ -115,7 +114,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ModulationParameters.h
+++ b/src/dis7/ModulationParameters.h
@@ -1,5 +1,4 @@
-#ifndef MODULATIONPARAMETERS_H
-#define MODULATIONPARAMETERS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -31,7 +30,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ModulationType.h
+++ b/src/dis7/ModulationType.h
@@ -1,5 +1,4 @@
-#ifndef MODULATIONTYPE_H
-#define MODULATIONTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Munition.h
+++ b/src/dis7/Munition.h
@@ -1,5 +1,4 @@
-#ifndef MUNITION_H
-#define MUNITION_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -63,7 +62,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MunitionDescriptor.h
+++ b/src/dis7/MunitionDescriptor.h
@@ -1,5 +1,4 @@
-#ifndef MUNITIONDESCRIPTOR_H
-#define MUNITIONDESCRIPTOR_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -63,7 +62,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/MunitionReload.h
+++ b/src/dis7/MunitionReload.h
@@ -1,5 +1,4 @@
-#ifndef MUNITIONRELOAD_H
-#define MUNITIONRELOAD_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -69,7 +68,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/NamedLocationIdentification.h
+++ b/src/dis7/NamedLocationIdentification.h
@@ -1,5 +1,4 @@
-#ifndef NAMEDLOCATIONIDENTIFICATION_H
-#define NAMEDLOCATIONIDENTIFICATION_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ObjectIdentifier.h
+++ b/src/dis7/ObjectIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef OBJECTIDENTIFIER_H
-#define OBJECTIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ObjectType.h
+++ b/src/dis7/ObjectType.h
@@ -1,5 +1,4 @@
-#ifndef OBJECTTYPE_H
-#define OBJECTTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/OneByteChunk.h
+++ b/src/dis7/OneByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef ONEBYTECHUNK_H
-#define ONEBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/OwnershipStatus.h
+++ b/src/dis7/OwnershipStatus.h
@@ -1,5 +1,4 @@
-#ifndef OWNERSHIPSTATUS_H
-#define OWNERSHIPSTATUS_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Pdu.h
+++ b/src/dis7/Pdu.h
@@ -1,5 +1,4 @@
-#ifndef PDU_H
-#define PDU_H
+#pragma once
 
 #include <dis7/PduSuperclass.h>
 #include <utils/DataStream.h>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PduContainer.h
+++ b/src/dis7/PduContainer.h
@@ -1,5 +1,4 @@
-#ifndef PDUCONTAINER_H
-#define PDUCONTAINER_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <vector>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PduHeader.h
+++ b/src/dis7/PduHeader.h
@@ -1,5 +1,4 @@
-#ifndef PDUHEADER_H
-#define PDUHEADER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -79,7 +78,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PduStatus.h
+++ b/src/dis7/PduStatus.h
@@ -1,5 +1,4 @@
-#ifndef PDUSTATUS_H
-#define PDUSTATUS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -37,7 +36,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PduSuperclass.h
+++ b/src/dis7/PduSuperclass.h
@@ -1,5 +1,4 @@
-#ifndef PDUSUPERCLASS_H
-#define PDUSUPERCLASS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PointObjectStatePdu.h
+++ b/src/dis7/PointObjectStatePdu.h
@@ -1,5 +1,4 @@
-#ifndef POINTOBJECTSTATEPDU_H
-#define POINTOBJECTSTATEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -118,7 +117,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/PropulsionSystemData.h
+++ b/src/dis7/PropulsionSystemData.h
@@ -1,5 +1,4 @@
-#ifndef PROPULSIONSYSTEMDATA_H
-#define PROPULSIONSYSTEMDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RadioCommunicationsFamilyPdu.h
+++ b/src/dis7/RadioCommunicationsFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef RADIOCOMMUNICATIONSFAMILYPDU_H
-#define RADIOCOMMUNICATIONSFAMILYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/Pdu.h>
@@ -46,7 +45,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RadioIdentifier.h
+++ b/src/dis7/RadioIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef RADIOIDENTIFIER_H
-#define RADIOIDENTIFIER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RadioType.h
+++ b/src/dis7/RadioType.h
@@ -1,5 +1,4 @@
-#ifndef RADIOTYPE_H
-#define RADIOTYPE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ReceiverPdu.h
+++ b/src/dis7/ReceiverPdu.h
@@ -1,5 +1,4 @@
-#ifndef RECEIVERPDU_H
-#define RECEIVERPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/RadioCommunicationsFamilyPdu.h>
@@ -64,7 +63,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RecordQueryReliablePdu.h
+++ b/src/dis7/RecordQueryReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef RECORDQUERYRELIABLEPDU_H
-#define RECORDQUERYRELIABLEPDU_H
+#pragma once
 
 #include <dis7/FourByteChunk.h>
 #include <vector>
@@ -82,7 +81,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RecordQuerySpecification.h
+++ b/src/dis7/RecordQuerySpecification.h
@@ -1,5 +1,4 @@
-#ifndef RECORDQUERYSPECIFICATION_H
-#define RECORDQUERYSPECIFICATION_H
+#pragma once
 
 #include <dis7/FourByteChunk.h>
 #include <vector>
@@ -44,7 +43,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RecordSpecification.h
+++ b/src/dis7/RecordSpecification.h
@@ -1,5 +1,4 @@
-#ifndef RECORDSPECIFICATION_H
-#define RECORDSPECIFICATION_H
+#pragma once
 
 #include <dis7/RecordSpecificationElement.h>
 #include <vector>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RecordSpecificationElement.h
+++ b/src/dis7/RecordSpecificationElement.h
@@ -1,5 +1,4 @@
-#ifndef RECORDSPECIFICATIONELEMENT_H
-#define RECORDSPECIFICATIONELEMENT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Relationship.h
+++ b/src/dis7/Relationship.h
@@ -1,5 +1,4 @@
-#ifndef RELATIONSHIP_H
-#define RELATIONSHIP_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RemoveEntityPdu.h
+++ b/src/dis7/RemoveEntityPdu.h
@@ -1,5 +1,4 @@
-#ifndef REMOVEENTITYPDU_H
-#define REMOVEENTITYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -54,7 +53,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RemoveEntityReliablePdu.h
+++ b/src/dis7/RemoveEntityReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef REMOVEENTITYRELIABLEPDU_H
-#define REMOVEENTITYRELIABLEPDU_H
+#pragma once
 
 #include <dis7/SimulationManagementWithReliabilityFamilyPdu.h>
 #include <utils/DataStream.h>
@@ -56,7 +55,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RepairCompletePdu.h
+++ b/src/dis7/RepairCompletePdu.h
@@ -1,5 +1,4 @@
-#ifndef REPAIRCOMPLETEPDU_H
-#define REPAIRCOMPLETEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -60,7 +59,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/RepairResponsePdu.h
+++ b/src/dis7/RepairResponsePdu.h
@@ -1,5 +1,4 @@
-#ifndef REPAIRRESPONSEPDU_H
-#define REPAIRRESPONSEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -66,7 +65,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ResupplyOfferPdu.h
+++ b/src/dis7/ResupplyOfferPdu.h
@@ -1,5 +1,4 @@
-#ifndef RESUPPLYOFFERPDU_H
-#define RESUPPLYOFFERPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -74,7 +73,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ResupplyReceivedPdu.h
+++ b/src/dis7/ResupplyReceivedPdu.h
@@ -1,5 +1,4 @@
-#ifndef RESUPPLYRECEIVEDPDU_H
-#define RESUPPLYRECEIVEDPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -74,7 +73,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SecondaryOperationalData.h
+++ b/src/dis7/SecondaryOperationalData.h
@@ -1,5 +1,4 @@
-#ifndef SECONDARYOPERATIONALDATA_H
-#define SECONDARYOPERATIONALDATA_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SeesPdu.h
+++ b/src/dis7/SeesPdu.h
@@ -1,5 +1,4 @@
-#ifndef SEESPDU_H
-#define SEESPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/PropulsionSystemData.h>
@@ -85,7 +84,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Sensor.h
+++ b/src/dis7/Sensor.h
@@ -1,5 +1,4 @@
-#ifndef SENSOR_H
-#define SENSOR_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SeparationVP.h
+++ b/src/dis7/SeparationVP.h
@@ -1,5 +1,4 @@
-#ifndef SEPARATIONVP_H
-#define SEPARATIONVP_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -75,7 +74,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/ServiceRequestPdu.h
+++ b/src/dis7/ServiceRequestPdu.h
@@ -1,5 +1,4 @@
-#ifndef SERVICEREQUESTPDU_H
-#define SERVICEREQUESTPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -73,7 +72,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SetDataPdu.h
+++ b/src/dis7/SetDataPdu.h
@@ -1,5 +1,4 @@
-#ifndef SETDATAPDU_H
-#define SETDATAPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -71,7 +70,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SetDataReliablePdu.h
+++ b/src/dis7/SetDataReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef SETDATARELIABLEPDU_H
-#define SETDATARELIABLEPDU_H
+#pragma once
 
 #include <dis7/FixedDatum.h>
 #include <dis7/VariableDatum.h>
@@ -83,7 +82,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SimulationAddress.h
+++ b/src/dis7/SimulationAddress.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONADDRESS_H
-#define SIMULATIONADDRESS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SimulationIdentifier.h
+++ b/src/dis7/SimulationIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONIDENTIFIER_H
-#define SIMULATIONIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SimulationManagementFamilyPdu.h
+++ b/src/dis7/SimulationManagementFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONMANAGEMENTFAMILYPDU_H
-#define SIMULATIONMANAGEMENTFAMILYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SimulationManagementPduHeader.h
+++ b/src/dis7/SimulationManagementPduHeader.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONMANAGEMENTPDUHEADER_H
-#define SIMULATIONMANAGEMENTPDUHEADER_H
+#pragma once
 
 #include <dis7/PduHeader.h>
 #include <dis7/EntityID.h>
@@ -55,7 +54,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SimulationManagementWithReliabilityFamilyPdu.h
+++ b/src/dis7/SimulationManagementWithReliabilityFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SIMULATIONMANAGEMENTWITHRELIABILITYFAMILYPDU_H
-#define SIMULATIONMANAGEMENTWITHRELIABILITYFAMILYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StandardVariableSpecification.h
+++ b/src/dis7/StandardVariableSpecification.h
@@ -1,5 +1,4 @@
-#ifndef STANDARDVARIABLESPECIFICATION_H
-#define STANDARDVARIABLESPECIFICATION_H
+#pragma once
 
 #include <dis7/SimulationManagementPduHeader.h>
 #include <vector>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StartResumePdu.h
+++ b/src/dis7/StartResumePdu.h
@@ -1,5 +1,4 @@
-#ifndef STARTRESUMEPDU_H
-#define STARTRESUMEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -70,7 +69,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StartResumeReliablePdu.h
+++ b/src/dis7/StartResumeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef STARTRESUMERELIABLEPDU_H
-#define STARTRESUMERELIABLEPDU_H
+#pragma once
 
 #include <dis7/ClockTime.h>
 #include <dis7/ClockTime.h>
@@ -72,7 +71,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StopFreezePdu.h
+++ b/src/dis7/StopFreezePdu.h
@@ -1,5 +1,4 @@
-#ifndef STOPFREEZEPDU_H
-#define STOPFREEZEPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -80,7 +79,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StopFreezeReliablePdu.h
+++ b/src/dis7/StopFreezeReliablePdu.h
@@ -1,5 +1,4 @@
-#ifndef STOPFREEZERELIABLEPDU_H
-#define STOPFREEZERELIABLEPDU_H
+#pragma once
 
 #include <dis7/ClockTime.h>
 #include <dis7/SimulationManagementWithReliabilityFamilyPdu.h>
@@ -70,7 +69,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StorageFuel.h
+++ b/src/dis7/StorageFuel.h
@@ -1,5 +1,4 @@
-#ifndef STORAGEFUEL_H
-#define STORAGEFUEL_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/StorageFuelReload.h
+++ b/src/dis7/StorageFuelReload.h
@@ -1,5 +1,4 @@
-#ifndef STORAGEFUELRELOAD_H
-#define STORAGEFUELRELOAD_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -79,7 +78,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SupplyQuantity.h
+++ b/src/dis7/SupplyQuantity.h
@@ -1,5 +1,4 @@
-#ifndef SUPPLYQUANTITY_H
-#define SUPPLYQUANTITY_H
+#pragma once
 
 #include <dis7/EntityType.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SyntheticEnvironmentFamilyPdu.h
+++ b/src/dis7/SyntheticEnvironmentFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef SYNTHETICENVIRONMENTFAMILYPDU_H
-#define SYNTHETICENVIRONMENTFAMILYPDU_H
+#pragma once
 
 #include <dis7/Pdu.h>
 #include <utils/DataStream.h>
@@ -32,7 +31,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/SystemIdentifier.h
+++ b/src/dis7/SystemIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef SYSTEMIDENTIFIER_H
-#define SYSTEMIDENTIFIER_H
+#pragma once
 
 #include <dis7/ChangeOptions.h>
 #include <utils/DataStream.h>
@@ -57,7 +56,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/TotalRecordSets.h
+++ b/src/dis7/TotalRecordSets.h
@@ -1,5 +1,4 @@
-#ifndef TOTALRECORDSETS_H
-#define TOTALRECORDSETS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/TrackJamData.h
+++ b/src/dis7/TrackJamData.h
@@ -1,5 +1,4 @@
-#ifndef TRACKJAMDATA_H
-#define TRACKJAMDATA_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <utils/DataStream.h>
@@ -51,7 +50,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/TwoByteChunk.h
+++ b/src/dis7/TwoByteChunk.h
@@ -1,5 +1,4 @@
-#ifndef TWOBYTECHUNK_H
-#define TWOBYTECHUNK_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -38,7 +37,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/UAFundamentalParameter.h
+++ b/src/dis7/UAFundamentalParameter.h
@@ -1,5 +1,4 @@
-#ifndef UAFUNDAMENTALPARAMETER_H
-#define UAFUNDAMENTALPARAMETER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -67,7 +66,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/UaPdu.h
+++ b/src/dis7/UaPdu.h
@@ -1,5 +1,4 @@
-#ifndef UAPDU_H
-#define UAPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EventIdentifier.h>
@@ -112,7 +111,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/UnattachedIdentifier.h
+++ b/src/dis7/UnattachedIdentifier.h
@@ -1,5 +1,4 @@
-#ifndef UNATTACHEDIDENTIFIER_H
-#define UNATTACHEDIDENTIFIER_H
+#pragma once
 
 #include <dis7/SimulationAddress.h>
 #include <utils/DataStream.h>
@@ -45,7 +44,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/UnsignedDISInteger.h
+++ b/src/dis7/UnsignedDISInteger.h
@@ -1,5 +1,4 @@
-#ifndef UNSIGNEDDISINTEGER_H
-#define UNSIGNEDDISINTEGER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -37,7 +36,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/VariableDatum.h
+++ b/src/dis7/VariableDatum.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLEDATUM_H
-#define VARIABLEDATUM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -60,7 +59,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/VariableParameter.h
+++ b/src/dis7/VariableParameter.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLEPARAMETER_H
-#define VARIABLEPARAMETER_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -61,7 +60,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/VariableTransmitterParameters.h
+++ b/src/dis7/VariableTransmitterParameters.h
@@ -1,5 +1,4 @@
-#ifndef VARIABLETRANSMITTERPARAMETERS_H
-#define VARIABLETRANSMITTERPARAMETERS_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Vector2Float.h
+++ b/src/dis7/Vector2Float.h
@@ -1,5 +1,4 @@
-#ifndef VECTOR2FLOAT_H
-#define VECTOR2FLOAT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Vector3Double.h
+++ b/src/dis7/Vector3Double.h
@@ -1,5 +1,4 @@
-#ifndef VECTOR3DOUBLE_H
-#define VECTOR3DOUBLE_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/Vector3Float.h
+++ b/src/dis7/Vector3Float.h
@@ -1,5 +1,4 @@
-#ifndef VECTOR3FLOAT_H
-#define VECTOR3FLOAT_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -49,7 +48,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/VectoringNozzleSystem.h
+++ b/src/dis7/VectoringNozzleSystem.h
@@ -1,5 +1,4 @@
-#ifndef VECTORINGNOZZLESYSTEM_H
-#define VECTORINGNOZZLESYSTEM_H
+#pragma once
 
 #include <utils/DataStream.h>
 #include <dis7/msLibMacro.h>
@@ -43,7 +42,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/dis7/WarfareFamilyPdu.h
+++ b/src/dis7/WarfareFamilyPdu.h
@@ -1,5 +1,4 @@
-#ifndef WARFAREFAMILYPDU_H
-#define WARFAREFAMILYPDU_H
+#pragma once
 
 #include <dis7/EntityID.h>
 #include <dis7/EntityID.h>
@@ -48,7 +47,6 @@ virtual int getMarshalledSize() const;
 };
 }
 
-#endif
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/utils/IPduBank.h
+++ b/src/utils/IPduBank.h
@@ -1,5 +1,4 @@
-#ifndef _IPDU_BANK_H_
-#define _IPDU_BANK_H_
+#pragma once_
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>
@@ -20,5 +19,4 @@ namespace DIS
     };   
 }
 
-#endif // _IPDU_BANK_H_
 

--- a/src/utils/PDUBank.h
+++ b/src/utils/PDUBank.h
@@ -1,5 +1,4 @@
-#ifndef _PDU_BANK_H_
-#define _PDU_BANK_H_
+#pragma once_
 
 #include <dis6/Pdu.h>
 #include <utils/PDUType.h>
@@ -19,5 +18,4 @@ namespace DIS
     };   
 }
 
-#endif // _PDU_BANK_H_
 


### PR DESCRIPTION
Replaces all include guards with #pragma once, as discussed in issue #51 .
 `./src/dis7/msLibMacro.h` is omitted to avoid merge conflicts with the pending WIP PR #44, which removes the file.