### PR TITLE
Secure processing of PDUs (avoid potential segfault)

### DIFF
--- a/src/utils/DataStream.cpp
+++ b/src/utils/DataStream.cpp
@@ -157,7 +157,7 @@ void DataStream::DoRead(char* ch, size_t bufsize)
 {
    for(unsigned int i=0; i<bufsize; i++)
    {
-      ch[i] = _buffer.at([_read_pos+i);
+      ch[i] = _buffer.at(_read_pos+i);
    }
 }
 

--- a/src/utils/DataStream.cpp
+++ b/src/utils/DataStream.cpp
@@ -157,7 +157,7 @@ void DataStream::DoRead(char* ch, size_t bufsize)
 {
    for(unsigned int i=0; i<bufsize; i++)
    {
-      ch[i] = _buffer[_read_pos+i];
+      ch[i] = _buffer.at([_read_pos+i);
    }
 }
 


### PR DESCRIPTION
If a PDU is malformed (especially if it has variable data), it can happen that unmarshal tries to access areas outside of the buffer.