### PR TITLE
fix IFFPdu bugs

### DIFF
--- a/src/dis7/IFFPdu.cpp
+++ b/src/dis7/IFFPdu.cpp
@@ -198,7 +198,6 @@ void IFFPdu::marshal(DataStream& dataStream) const
     _beamData.marshal(dataStream);
     _secondaryOperationalData.marshal(dataStream);
     dataStream << ( unsigned char )_iffParameters.size();
-
     for(size_t idx = 0; idx < _iffParameters.size(); idx++)
     {
         IFFFundamentalParameterData x = _iffParameters[idx];
@@ -213,7 +212,6 @@ void IFFPdu::unmarshal(DataStream& dataStream)
     _emittingEntityID.unmarshal(dataStream);
     _eventID.unmarshal(dataStream);
     _relativeAntennaLocation.unmarshal(dataStream);
-    dataStream >> _numberOfIFFParameters;
     _systemID.unmarshal(dataStream);
     dataStream >> _systemDesignator;
     dataStream >> _systemSpecificData;
@@ -221,7 +219,7 @@ void IFFPdu::unmarshal(DataStream& dataStream)
     _layerHeader.unmarshal(dataStream);
     _beamData.unmarshal(dataStream);
     _secondaryOperationalData.unmarshal(dataStream);
-
+    _numberOfIFFParameters = _secondaryOperationalData.getNumberOfIFFFundamentalParameterRecords();
     _iffParameters.clear();
     for(size_t idx = 0; idx < _numberOfIFFParameters; idx++)
     {

--- a/src/dis7/SystemIdentifier.cpp
+++ b/src/dis7/SystemIdentifier.cpp
@@ -35,12 +35,12 @@ void SystemIdentifier::setSystemName(unsigned short pX)
     _systemName = pX;
 }
 
-unsigned short SystemIdentifier::getSystemMode() const
+unsigned char SystemIdentifier::getSystemMode() const
 {
     return _systemMode;
 }
 
-void SystemIdentifier::setSystemMode(unsigned short pX)
+void SystemIdentifier::setSystemMode(unsigned char pX)
 {
     _systemMode = pX;
 }

--- a/src/dis7/SystemIdentifier.h
+++ b/src/dis7/SystemIdentifier.h
@@ -22,7 +22,7 @@ protected:
   unsigned short _systemName; 
 
   /** mode of operation for the system, an enumeration */
-  unsigned short _systemMode; 
+  unsigned char _systemMode; 
 
   /** status of this PDU, see section 6.2.15 */
   unsigned char _changeOptions;
@@ -41,8 +41,8 @@ protected:
     unsigned short getSystemName() const; 
     void setSystemName(unsigned short pX); 
 
-    unsigned short getSystemMode() const; 
-    void setSystemMode(unsigned short pX); 
+    unsigned char getSystemMode() const; 
+    void setSystemMode(unsigned char pX); 
 
     unsigned char getChangeOptions() const;
     void setChangeOptions(unsigned char pX);


### PR DESCRIPTION
Some bugs fixed: 

- unmarshal() had a counter for IFF parameters on the wrong position and would produce a core dump.
- SystemIdentifier._systemMode shall be 8-bit, but it was defined as a unsigned short (16bit)