### PR TITLE
Fix mistakes in PR#59 (trailing _ on pragma once)

### DIFF
--- a/src/dis6/symbolic_names.h
+++ b/src/dis6/symbolic_names.h
@@ -1,4 +1,4 @@
-#pragma once_INCLUDED
+#pragma once
 
 #include <dis6/EntityID.h>
 

--- a/src/utils/IPduBank.h
+++ b/src/utils/IPduBank.h
@@ -1,4 +1,4 @@
-#pragma once_
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/DataStream.h>

--- a/src/utils/PDUBank.h
+++ b/src/utils/PDUBank.h
@@ -1,4 +1,4 @@
-#pragma once_
+#pragma once
 
 #include <dis6/Pdu.h>
 #include <utils/PDUType.h>


### PR DESCRIPTION
Noticed that #59 didn't quite replace all include guard properly with #pragma once
2 had trailing underscores, and one had _INCLUDED
Fixed up now.