### PR TITLE
Minor issue. 1278 specifies that the beam data length is a char

### DIFF
--- a/src/dis6/AcousticBeamData.cpp
+++ b/src/dis6/AcousticBeamData.cpp
@@ -93,7 +93,7 @@ int AcousticBeamData::getMarshalledSize() const
 {
    int marshalSize = 0;
 
-   marshalSize = marshalSize + 2;  // _beamDataLength
+   marshalSize = marshalSize + 1;  // _beamDataLength
    marshalSize = marshalSize + 1;  // _beamIDNumber
    marshalSize = marshalSize + 2;  // _pad2
    marshalSize = marshalSize + _fundamentalDataParameters.getMarshalledSize();  // _fundamentalDataParameters

--- a/src/dis6/AcousticBeamData.h
+++ b/src/dis6/AcousticBeamData.h
@@ -17,7 +17,7 @@ class EXPORT_MACRO AcousticBeamData
 {
 protected:
   /** beam data length */
-  unsigned short _beamDataLength; 
+  unsigned char _beamDataLength; 
 
   /** beamIDNumber */
   unsigned char _beamIDNumber; 


### PR DESCRIPTION
I'm not certain about the DIS7 implementation, but it looks like the DIS6 UaPDU has a slight problem with the Acoustic Beam Data struct. The beam data length field is listed as a 8 bit value in the 1278 spec so I changed it from a short to a char and adjusted the marshalled size function by one as well.