### PR TITLE
Tweak cmake target install so dlls will go in the proper location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,11 @@ if(BUILD_TESTS)
 endif()
 
 # Configure install target (i.e. what files to install)
-install(TARGETS OpenDIS6 OpenDIS7 EXPORT OpenDISTargets DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS OpenDIS6 OpenDIS7
+        EXPORT OpenDISTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(EXPORT OpenDISTargets
         NAMESPACE OpenDIS::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/OpenDIS")


### PR DESCRIPTION
Found an issue while working #63. DLLs were being installed to 'lib' instead of 'bin' on windows. This corrects that issue.