### PR TITLE
Singal PDU dataLength should be in bits, not bytes (DIS 6)

### DIFF
--- a/src/dis6/SignalPdu.cpp
+++ b/src/dis6/SignalPdu.cpp
@@ -4,7 +4,8 @@ using namespace DIS;
 
 SignalPdu::SignalPdu()
     : RadioCommunicationsFamilyPdu(), _encodingScheme(0), _tdlType(0),
-      _sampleRate(0), _dataLength(0), _samples(0) {
+      _sampleRate(0), _dataLength(0), _samples(0)
+{
   setPduType(26);
 }
 
@@ -22,7 +23,9 @@ unsigned int SignalPdu::getSampleRate() const { return _sampleRate; }
 
 void SignalPdu::setSampleRate(unsigned int pX) { _sampleRate = pX; }
 
-short SignalPdu::getDataLength() const { return _data.size(); }
+short SignalPdu::getDataLength() const { return _dataLength; }
+
+void SignalPdu::setDataLength(short pX) { _dataLength = pX; }
 
 short SignalPdu::getSamples() const { return _samples; }
 
@@ -34,20 +37,23 @@ const std::vector<uint8_t> &SignalPdu::getData() const { return _data; }
 
 void SignalPdu::setData(const std::vector<uint8_t> &pX) { _data = pX; }
 
-void SignalPdu::marshal(DataStream &dataStream) const {
+void SignalPdu::marshal(DataStream &dataStream) const
+{
   RadioCommunicationsFamilyPdu::marshal(
       dataStream); // Marshal information in superclass first
   dataStream << _encodingScheme;
   dataStream << _tdlType;
   dataStream << _sampleRate;
-  dataStream << (short)_data.size();
+  dataStream << (short)_dataLength;
   dataStream << _samples;
-  for (auto byte : _data) {
+  for (auto byte : _data)
+  {
     dataStream << byte;
   }
 }
 
-void SignalPdu::unmarshal(DataStream &dataStream) {
+void SignalPdu::unmarshal(DataStream &dataStream)
+{
   RadioCommunicationsFamilyPdu::unmarshal(
       dataStream); // unmarshal information in superclass first
   dataStream >> _encodingScheme;
@@ -57,14 +63,17 @@ void SignalPdu::unmarshal(DataStream &dataStream) {
   dataStream >> _samples;
 
   _data.clear();
-  for (auto idx = 0; idx < _dataLength; ++idx) {
+  const int dataLengthBytes = (_dataLength + 7) / 8; // bits to bytes
+  for (auto idx = 0; idx < dataLengthBytes; ++idx)
+  {
     uint8_t x;
     dataStream >> x;
     _data.push_back(x);
   }
 }
 
-bool SignalPdu::operator==(const SignalPdu &rhs) const {
+bool SignalPdu::operator==(const SignalPdu &rhs) const
+{
   auto ivarsEqual = true;
 
   ivarsEqual = RadioCommunicationsFamilyPdu::operator==(rhs) &&
@@ -75,7 +84,8 @@ bool SignalPdu::operator==(const SignalPdu &rhs) const {
   return ivarsEqual;
 }
 
-int SignalPdu::getMarshalledSize() const {
+int SignalPdu::getMarshalledSize() const
+{
   auto marshalSize = 0;
 
   marshalSize = RadioCommunicationsFamilyPdu::getMarshalledSize();

--- a/src/dis6/SignalPdu.h
+++ b/src/dis6/SignalPdu.h
@@ -6,66 +6,69 @@
 #include <cstdint>
 #include <vector>
 
-namespace DIS {
-// Section 5.3.8.2. Detailed information about a radio transmitter. This PDU
-// requires        manually written code to complete. The encodingScheme field
-// can be used in multiple        ways, which requires hand-written code to
-// finish. UNFINISHED
+namespace DIS
+{
+  // Section 5.3.8.2. Detailed information about a radio transmitter. This PDU
+  // requires        manually written code to complete. The encodingScheme field
+  // can be used in multiple        ways, which requires hand-written code to
+  // finish. UNFINISHED
 
-// Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All
-// rights reserved.
-//
-// @author DMcG, jkg
+  // Copyright (c) 2007-2009, MOVES Institute, Naval Postgraduate School. All
+  // rights reserved.
+  //
+  // @author DMcG, jkg
 
-class OPENDIS6_EXPORT SignalPdu : public RadioCommunicationsFamilyPdu {
-protected:
-  /** encoding scheme used, and enumeration */
-  unsigned short _encodingScheme;
+  class OPENDIS6_EXPORT SignalPdu : public RadioCommunicationsFamilyPdu
+  {
+  protected:
+    /** encoding scheme used, and enumeration */
+    unsigned short _encodingScheme;
 
-  /** tdl type */
-  unsigned short _tdlType;
+    /** tdl type */
+    unsigned short _tdlType;
 
-  /** sample rate */
-  unsigned int _sampleRate;
+    /** sample rate */
+    unsigned int _sampleRate;
 
-  /** length od data */
-  short _dataLength;
+    /** length od data */
+    short _dataLength;
 
-  /** number of samples */
-  short _samples;
+    /** number of samples */
+    short _samples;
 
-  /** list of eight bit values */
-  std::vector<uint8_t> _data;
+    /** list of eight bit values */
+    std::vector<uint8_t> _data;
 
-public:
-  SignalPdu();
-  virtual ~SignalPdu();
+  public:
+    SignalPdu();
+    virtual ~SignalPdu();
 
-  virtual void marshal(DataStream &dataStream) const;
-  virtual void unmarshal(DataStream &dataStream);
+    virtual void marshal(DataStream &dataStream) const;
+    virtual void unmarshal(DataStream &dataStream);
 
-  unsigned short getEncodingScheme() const;
-  void setEncodingScheme(unsigned short pX);
+    unsigned short getEncodingScheme() const;
+    void setEncodingScheme(unsigned short pX);
 
-  unsigned short getTdlType() const;
-  void setTdlType(unsigned short pX);
+    unsigned short getTdlType() const;
+    void setTdlType(unsigned short pX);
 
-  unsigned int getSampleRate() const;
-  void setSampleRate(unsigned int pX);
+    unsigned int getSampleRate() const;
+    void setSampleRate(unsigned int pX);
 
-  short getDataLength() const;
+    short getDataLength() const;
+    void setDataLength(short pX);
 
-  short getSamples() const;
-  void setSamples(short pX);
+    short getSamples() const;
+    void setSamples(short pX);
 
-  std::vector<uint8_t> &getData();
-  const std::vector<uint8_t> &getData() const;
-  void setData(const std::vector<uint8_t> &pX);
+    std::vector<uint8_t> &getData();
+    const std::vector<uint8_t> &getData() const;
+    void setData(const std::vector<uint8_t> &pX);
 
-  virtual int getMarshalledSize() const;
+    virtual int getMarshalledSize() const;
 
-  bool operator==(const SignalPdu &rhs) const;
-};
+    bool operator==(const SignalPdu &rhs) const;
+  };
 } // namespace DIS
 
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.


### PR DESCRIPTION
As per the spec, the data length is meant to be indicated in bits, not bytes. I've used the fix in the Java version of open-dis as a basis for this pull request. See https://github.com/open-dis/open-dis-java/commit/9b20d4d0f0992157dcd4a0ecf1e8ae62717e984e#diff-5d13a4f131b76879516bb03083caae46

Related issues here: https://github.com/open-dis/open-dis-cpp/issues/10 and here: https://github.com/open-dis/open-dis-cpp/issues/84