### PR TITLE
Remove duplicate _originatingID and _receivingID fields

### DIFF
--- a/src/dis7/AcknowledgePdu.cpp
+++ b/src/dis7/AcknowledgePdu.cpp
@@ -4,8 +4,6 @@ using namespace DIS;
 
 
 AcknowledgePdu::AcknowledgePdu() : SimulationManagementFamilyPdu(),
-   _originatingID(), 
-   _receivingID(), 
    _acknowledgeFlag(0), 
    _responseFlag(0), 
    _requestID(0)
@@ -15,36 +13,6 @@ AcknowledgePdu::AcknowledgePdu() : SimulationManagementFamilyPdu(),
 
 AcknowledgePdu::~AcknowledgePdu()
 {
-}
-
-EntityID& AcknowledgePdu::getOriginatingID() 
-{
-    return _originatingID;
-}
-
-const EntityID& AcknowledgePdu::getOriginatingID() const
-{
-    return _originatingID;
-}
-
-void AcknowledgePdu::setOriginatingID(const EntityID &pX)
-{
-    _originatingID = pX;
-}
-
-EntityID& AcknowledgePdu::getReceivingID() 
-{
-    return _receivingID;
-}
-
-const EntityID& AcknowledgePdu::getReceivingID() const
-{
-    return _receivingID;
-}
-
-void AcknowledgePdu::setReceivingID(const EntityID &pX)
-{
-    _receivingID = pX;
 }
 
 unsigned short AcknowledgePdu::getAcknowledgeFlag() const
@@ -80,8 +48,6 @@ void AcknowledgePdu::setRequestID(unsigned int pX)
 void AcknowledgePdu::marshal(DataStream& dataStream) const
 {
     SimulationManagementFamilyPdu::marshal(dataStream); // Marshal information in superclass first
-    _originatingID.marshal(dataStream);
-    _receivingID.marshal(dataStream);
     dataStream << _acknowledgeFlag;
     dataStream << _responseFlag;
     dataStream << _requestID;
@@ -90,8 +56,6 @@ void AcknowledgePdu::marshal(DataStream& dataStream) const
 void AcknowledgePdu::unmarshal(DataStream& dataStream)
 {
     SimulationManagementFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
-    _originatingID.unmarshal(dataStream);
-    _receivingID.unmarshal(dataStream);
     dataStream >> _acknowledgeFlag;
     dataStream >> _responseFlag;
     dataStream >> _requestID;
@@ -104,8 +68,6 @@ bool AcknowledgePdu::operator ==(const AcknowledgePdu& rhs) const
 
      ivarsEqual = SimulationManagementFamilyPdu::operator==(rhs);
 
-     if( ! (_originatingID == rhs._originatingID) ) ivarsEqual = false;
-     if( ! (_receivingID == rhs._receivingID) ) ivarsEqual = false;
      if( ! (_acknowledgeFlag == rhs._acknowledgeFlag) ) ivarsEqual = false;
      if( ! (_responseFlag == rhs._responseFlag) ) ivarsEqual = false;
      if( ! (_requestID == rhs._requestID) ) ivarsEqual = false;
@@ -118,8 +80,6 @@ int AcknowledgePdu::getMarshalledSize() const
    int marshalSize = 0;
 
    marshalSize = SimulationManagementFamilyPdu::getMarshalledSize();
-   marshalSize = marshalSize + _originatingID.getMarshalledSize();  // _originatingID
-   marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + 2;  // _acknowledgeFlag
    marshalSize = marshalSize + 2;  // _responseFlag
    marshalSize = marshalSize + 4;  // _requestID

--- a/src/dis7/AcknowledgePdu.h
+++ b/src/dis7/AcknowledgePdu.h
@@ -18,12 +18,6 @@ namespace DIS
 class OPENDIS7_EXPORT AcknowledgePdu : public SimulationManagementFamilyPdu
 {
 protected:
-  /** Identifier for originating entity(or simulation) */
-  EntityID _originatingID; 
-
-  /** Identifier for the receiving entity(or simulation) */
-  EntityID _receivingID; 
-
   /** type of message being acknowledged */
   unsigned short _acknowledgeFlag; 
 
@@ -40,14 +34,6 @@ protected:
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
-
-    EntityID& getOriginatingID(); 
-    const EntityID&  getOriginatingID() const; 
-    void setOriginatingID(const EntityID    &pX);
-
-    EntityID& getReceivingID(); 
-    const EntityID&  getReceivingID() const; 
-    void setReceivingID(const EntityID    &pX);
 
     unsigned short getAcknowledgeFlag() const; 
     void setAcknowledgeFlag(unsigned short pX); 

--- a/src/dis7/ActionRequestPdu.cpp
+++ b/src/dis7/ActionRequestPdu.cpp
@@ -4,8 +4,6 @@ using namespace DIS;
 
 
 ActionRequestPdu::ActionRequestPdu() : SimulationManagementFamilyPdu(),
-   _originatingID(), 
-   _receivingID(), 
    _requestID(0), 
    _actionID(0), 
    _numberOfFixedDatumRecords(0), 
@@ -18,36 +16,6 @@ ActionRequestPdu::~ActionRequestPdu()
 {
     _fixedDatums.clear();
     _variableDatums.clear();
-}
-
-EntityID& ActionRequestPdu::getOriginatingID() 
-{
-    return _originatingID;
-}
-
-const EntityID& ActionRequestPdu::getOriginatingID() const
-{
-    return _originatingID;
-}
-
-void ActionRequestPdu::setOriginatingID(const EntityID &pX)
-{
-    _originatingID = pX;
-}
-
-EntityID& ActionRequestPdu::getReceivingID() 
-{
-    return _receivingID;
-}
-
-const EntityID& ActionRequestPdu::getReceivingID() const
-{
-    return _receivingID;
-}
-
-void ActionRequestPdu::setReceivingID(const EntityID &pX)
-{
-    _receivingID = pX;
 }
 
 unsigned int ActionRequestPdu::getRequestID() const
@@ -113,8 +81,6 @@ void ActionRequestPdu::setVariableDatums(const std::vector<VariableDatum>& pX)
 void ActionRequestPdu::marshal(DataStream& dataStream) const
 {
     SimulationManagementFamilyPdu::marshal(dataStream); // Marshal information in superclass first
-    _originatingID.marshal(dataStream);
-    _receivingID.marshal(dataStream);
     dataStream << _requestID;
     dataStream << _actionID;
     dataStream << ( unsigned int )_fixedDatums.size();
@@ -138,8 +104,6 @@ void ActionRequestPdu::marshal(DataStream& dataStream) const
 void ActionRequestPdu::unmarshal(DataStream& dataStream)
 {
     SimulationManagementFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
-    _originatingID.unmarshal(dataStream);
-    _receivingID.unmarshal(dataStream);
     dataStream >> _requestID;
     dataStream >> _actionID;
     dataStream >> _numberOfFixedDatumRecords;
@@ -169,8 +133,6 @@ bool ActionRequestPdu::operator ==(const ActionRequestPdu& rhs) const
 
      ivarsEqual = SimulationManagementFamilyPdu::operator==(rhs);
 
-     if( ! (_originatingID == rhs._originatingID) ) ivarsEqual = false;
-     if( ! (_receivingID == rhs._receivingID) ) ivarsEqual = false;
      if( ! (_requestID == rhs._requestID) ) ivarsEqual = false;
      if( ! (_actionID == rhs._actionID) ) ivarsEqual = false;
 
@@ -194,8 +156,6 @@ int ActionRequestPdu::getMarshalledSize() const
    int marshalSize = 0;
 
    marshalSize = SimulationManagementFamilyPdu::getMarshalledSize();
-   marshalSize = marshalSize + _originatingID.getMarshalledSize();  // _originatingID
-   marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + 4;  // _requestID
    marshalSize = marshalSize + 4;  // _actionID
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords

--- a/src/dis7/ActionRequestPdu.h
+++ b/src/dis7/ActionRequestPdu.h
@@ -21,12 +21,6 @@ namespace DIS
 class OPENDIS7_EXPORT ActionRequestPdu : public SimulationManagementFamilyPdu
 {
 protected:
-  /** Identifier for originating entity(or simulation) */
-  EntityID _originatingID; 
-
-  /** Identifier for the receiving entity(or simulation) */
-  EntityID _receivingID; 
-
   /** identifies the request being made by the simulaton manager */
   unsigned int _requestID; 
 
@@ -53,13 +47,6 @@ protected:
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
 
-    EntityID& getOriginatingID(); 
-    const EntityID&  getOriginatingID() const; 
-    void setOriginatingID(const EntityID    &pX);
-
-    EntityID& getReceivingID(); 
-    const EntityID&  getReceivingID() const; 
-    void setReceivingID(const EntityID    &pX);
 
     unsigned int getRequestID() const; 
     void setRequestID(unsigned int pX); 

--- a/src/dis7/ActionResponsePdu.cpp
+++ b/src/dis7/ActionResponsePdu.cpp
@@ -4,8 +4,6 @@ using namespace DIS;
 
 
 ActionResponsePdu::ActionResponsePdu() : SimulationManagementFamilyPdu(),
-   _originatingID(), 
-   _receivingID(), 
    _requestID(0), 
    _requestStatus(0), 
    _numberOfFixedDatumRecords(0), 
@@ -18,36 +16,6 @@ ActionResponsePdu::~ActionResponsePdu()
 {
     _fixedDatums.clear();
     _variableDatums.clear();
-}
-
-EntityID& ActionResponsePdu::getOriginatingID() 
-{
-    return _originatingID;
-}
-
-const EntityID& ActionResponsePdu::getOriginatingID() const
-{
-    return _originatingID;
-}
-
-void ActionResponsePdu::setOriginatingID(const EntityID &pX)
-{
-    _originatingID = pX;
-}
-
-EntityID& ActionResponsePdu::getReceivingID() 
-{
-    return _receivingID;
-}
-
-const EntityID& ActionResponsePdu::getReceivingID() const
-{
-    return _receivingID;
-}
-
-void ActionResponsePdu::setReceivingID(const EntityID &pX)
-{
-    _receivingID = pX;
 }
 
 unsigned int ActionResponsePdu::getRequestID() const
@@ -113,8 +81,6 @@ void ActionResponsePdu::setVariableDatums(const std::vector<VariableDatum>& pX)
 void ActionResponsePdu::marshal(DataStream& dataStream) const
 {
     SimulationManagementFamilyPdu::marshal(dataStream); // Marshal information in superclass first
-    _originatingID.marshal(dataStream);
-    _receivingID.marshal(dataStream);
     dataStream << _requestID;
     dataStream << _requestStatus;
     dataStream << ( unsigned int )_fixedDatums.size();
@@ -138,8 +104,6 @@ void ActionResponsePdu::marshal(DataStream& dataStream) const
 void ActionResponsePdu::unmarshal(DataStream& dataStream)
 {
     SimulationManagementFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
-    _originatingID.unmarshal(dataStream);
-    _receivingID.unmarshal(dataStream);
     dataStream >> _requestID;
     dataStream >> _requestStatus;
     dataStream >> _numberOfFixedDatumRecords;
@@ -169,8 +133,6 @@ bool ActionResponsePdu::operator ==(const ActionResponsePdu& rhs) const
 
      ivarsEqual = SimulationManagementFamilyPdu::operator==(rhs);
 
-     if( ! (_originatingID == rhs._originatingID) ) ivarsEqual = false;
-     if( ! (_receivingID == rhs._receivingID) ) ivarsEqual = false;
      if( ! (_requestID == rhs._requestID) ) ivarsEqual = false;
      if( ! (_requestStatus == rhs._requestStatus) ) ivarsEqual = false;
 
@@ -194,8 +156,6 @@ int ActionResponsePdu::getMarshalledSize() const
    int marshalSize = 0;
 
    marshalSize = SimulationManagementFamilyPdu::getMarshalledSize();
-   marshalSize = marshalSize + _originatingID.getMarshalledSize();  // _originatingID
-   marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + 4;  // _requestID
    marshalSize = marshalSize + 4;  // _requestStatus
    marshalSize = marshalSize + 4;  // _numberOfFixedDatumRecords

--- a/src/dis7/ActionResponsePdu.h
+++ b/src/dis7/ActionResponsePdu.h
@@ -21,12 +21,6 @@ namespace DIS
 class OPENDIS7_EXPORT ActionResponsePdu : public SimulationManagementFamilyPdu
 {
 protected:
-  /** Identifier for originating entity(or simulation) */
-  EntityID _originatingID; 
-
-  /** Identifier for the receiving entity(or simulation) */
-  EntityID _receivingID; 
-
   /** Request ID that is unique */
   unsigned int _requestID; 
 
@@ -52,14 +46,6 @@ protected:
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
-
-    EntityID& getOriginatingID(); 
-    const EntityID&  getOriginatingID() const; 
-    void setOriginatingID(const EntityID    &pX);
-
-    EntityID& getReceivingID(); 
-    const EntityID&  getReceivingID() const; 
-    void setReceivingID(const EntityID    &pX);
 
     unsigned int getRequestID() const; 
     void setRequestID(unsigned int pX); 

--- a/src/dis7/CreateEntityPdu.cpp
+++ b/src/dis7/CreateEntityPdu.cpp
@@ -4,8 +4,6 @@ using namespace DIS;
 
 
 CreateEntityPdu::CreateEntityPdu() : SimulationManagementFamilyPdu(),
-   _originatingID(), 
-   _receivingID(), 
    _requestID(0)
 {
     setPduType( 11 );
@@ -13,36 +11,6 @@ CreateEntityPdu::CreateEntityPdu() : SimulationManagementFamilyPdu(),
 
 CreateEntityPdu::~CreateEntityPdu()
 {
-}
-
-EntityID& CreateEntityPdu::getOriginatingID() 
-{
-    return _originatingID;
-}
-
-const EntityID& CreateEntityPdu::getOriginatingID() const
-{
-    return _originatingID;
-}
-
-void CreateEntityPdu::setOriginatingID(const EntityID &pX)
-{
-    _originatingID = pX;
-}
-
-EntityID& CreateEntityPdu::getReceivingID() 
-{
-    return _receivingID;
-}
-
-const EntityID& CreateEntityPdu::getReceivingID() const
-{
-    return _receivingID;
-}
-
-void CreateEntityPdu::setReceivingID(const EntityID &pX)
-{
-    _receivingID = pX;
 }
 
 unsigned int CreateEntityPdu::getRequestID() const
@@ -58,16 +26,12 @@ void CreateEntityPdu::setRequestID(unsigned int pX)
 void CreateEntityPdu::marshal(DataStream& dataStream) const
 {
     SimulationManagementFamilyPdu::marshal(dataStream); // Marshal information in superclass first
-    _originatingID.marshal(dataStream);
-    _receivingID.marshal(dataStream);
     dataStream << _requestID;
 }
 
 void CreateEntityPdu::unmarshal(DataStream& dataStream)
 {
     SimulationManagementFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
-    _originatingID.unmarshal(dataStream);
-    _receivingID.unmarshal(dataStream);
     dataStream >> _requestID;
 }
 
@@ -77,9 +41,6 @@ bool CreateEntityPdu::operator ==(const CreateEntityPdu& rhs) const
      bool ivarsEqual = true;
 
      ivarsEqual = SimulationManagementFamilyPdu::operator==(rhs);
-
-     if( ! (_originatingID == rhs._originatingID) ) ivarsEqual = false;
-     if( ! (_receivingID == rhs._receivingID) ) ivarsEqual = false;
      if( ! (_requestID == rhs._requestID) ) ivarsEqual = false;
 
     return ivarsEqual;
@@ -90,8 +51,6 @@ int CreateEntityPdu::getMarshalledSize() const
    int marshalSize = 0;
 
    marshalSize = SimulationManagementFamilyPdu::getMarshalledSize();
-   marshalSize = marshalSize + _originatingID.getMarshalledSize();  // _originatingID
-   marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + 4;  // _requestID
     return marshalSize;
 }

--- a/src/dis7/CreateEntityPdu.h
+++ b/src/dis7/CreateEntityPdu.h
@@ -18,12 +18,6 @@ namespace DIS
 class OPENDIS7_EXPORT CreateEntityPdu : public SimulationManagementFamilyPdu
 {
 protected:
-  /** Identifier for the request */
-  EntityID _originatingID; 
-
-  /** Identifier for the request */
-  EntityID _receivingID; 
-
   /** Identifier for the request.  See 6.2.75 */
   unsigned int _requestID; 
 
@@ -34,14 +28,6 @@ protected:
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
-
-    EntityID& getOriginatingID(); 
-    const EntityID&  getOriginatingID() const; 
-    void setOriginatingID(const EntityID    &pX);
-
-    EntityID& getReceivingID(); 
-    const EntityID&  getReceivingID() const; 
-    void setReceivingID(const EntityID    &pX);
 
     unsigned int getRequestID() const; 
     void setRequestID(unsigned int pX); 

--- a/src/dis7/RemoveEntityPdu.cpp
+++ b/src/dis7/RemoveEntityPdu.cpp
@@ -4,8 +4,6 @@ using namespace DIS;
 
 
 RemoveEntityPdu::RemoveEntityPdu() : SimulationManagementFamilyPdu(),
-   _originatingID(), 
-   _receivingID(), 
    _requestID(0)
 {
     setPduType( 12 );
@@ -13,36 +11,6 @@ RemoveEntityPdu::RemoveEntityPdu() : SimulationManagementFamilyPdu(),
 
 RemoveEntityPdu::~RemoveEntityPdu()
 {
-}
-
-EntityID& RemoveEntityPdu::getOriginatingID() 
-{
-    return _originatingID;
-}
-
-const EntityID& RemoveEntityPdu::getOriginatingID() const
-{
-    return _originatingID;
-}
-
-void RemoveEntityPdu::setOriginatingID(const EntityID &pX)
-{
-    _originatingID = pX;
-}
-
-EntityID& RemoveEntityPdu::getReceivingID() 
-{
-    return _receivingID;
-}
-
-const EntityID& RemoveEntityPdu::getReceivingID() const
-{
-    return _receivingID;
-}
-
-void RemoveEntityPdu::setReceivingID(const EntityID &pX)
-{
-    _receivingID = pX;
 }
 
 unsigned int RemoveEntityPdu::getRequestID() const
@@ -58,16 +26,12 @@ void RemoveEntityPdu::setRequestID(unsigned int pX)
 void RemoveEntityPdu::marshal(DataStream& dataStream) const
 {
     SimulationManagementFamilyPdu::marshal(dataStream); // Marshal information in superclass first
-    _originatingID.marshal(dataStream);
-    _receivingID.marshal(dataStream);
     dataStream << _requestID;
 }
 
 void RemoveEntityPdu::unmarshal(DataStream& dataStream)
 {
     SimulationManagementFamilyPdu::unmarshal(dataStream); // unmarshal information in superclass first
-    _originatingID.unmarshal(dataStream);
-    _receivingID.unmarshal(dataStream);
     dataStream >> _requestID;
 }
 
@@ -78,8 +42,6 @@ bool RemoveEntityPdu::operator ==(const RemoveEntityPdu& rhs) const
 
      ivarsEqual = SimulationManagementFamilyPdu::operator==(rhs);
 
-     if( ! (_originatingID == rhs._originatingID) ) ivarsEqual = false;
-     if( ! (_receivingID == rhs._receivingID) ) ivarsEqual = false;
      if( ! (_requestID == rhs._requestID) ) ivarsEqual = false;
 
     return ivarsEqual;
@@ -90,8 +52,6 @@ int RemoveEntityPdu::getMarshalledSize() const
    int marshalSize = 0;
 
    marshalSize = SimulationManagementFamilyPdu::getMarshalledSize();
-   marshalSize = marshalSize + _originatingID.getMarshalledSize();  // _originatingID
-   marshalSize = marshalSize + _receivingID.getMarshalledSize();  // _receivingID
    marshalSize = marshalSize + 4;  // _requestID
     return marshalSize;
 }

--- a/src/dis7/RemoveEntityPdu.h
+++ b/src/dis7/RemoveEntityPdu.h
@@ -18,11 +18,6 @@ namespace DIS
 class OPENDIS7_EXPORT RemoveEntityPdu : public SimulationManagementFamilyPdu
 {
 protected:
-  /** Identifier for originating entity(or simulation) */
-  EntityID _originatingID; 
-
-  /** Identifier for the receiving entity(or simulation) */
-  EntityID _receivingID; 
 
   /** This field shall identify the specific and unique start/resume request being made by the SM */
   unsigned int _requestID; 
@@ -34,14 +29,6 @@ protected:
 
     virtual void marshal(DataStream& dataStream) const;
     virtual void unmarshal(DataStream& dataStream);
-
-    EntityID& getOriginatingID(); 
-    const EntityID&  getOriginatingID() const; 
-    void setOriginatingID(const EntityID    &pX);
-
-    EntityID& getReceivingID(); 
-    const EntityID&  getReceivingID() const; 
-    void setReceivingID(const EntityID    &pX);
 
     unsigned int getRequestID() const; 
     void setRequestID(unsigned int pX); 


### PR DESCRIPTION
Removing duplicate `_originatingID` and `_receivingID` that are already in parent class `SimulationManagementFamilyPdu`, which causes invalid serialization of PDUs.

This pr fixes #106 