### PR TITLE
Fix variable datum

### DIFF
--- a/src/dis7/VariableDatum.cpp
+++ b/src/dis7/VariableDatum.cpp
@@ -6,8 +6,8 @@ using namespace DIS;
 VariableDatum::VariableDatum():
    _variableDatumID(0), 
    _variableDatumLength(0), 
-   _variableDatumBits(0), 
-   _padding(0)
+   _variableDatums(static_cast<std::size_t>(STATIC_ARRAY_LENGTH), char(0)), // can (theoretically) throw
+   _arrayLength(0)
 {
 }
 
@@ -35,36 +35,51 @@ void VariableDatum::setVariableDatumLength(unsigned int pX)
     _variableDatumLength = pX;
 }
 
-unsigned int VariableDatum::getVariableDatumBits() const
+char* VariableDatum::getVariableDatums() // a bit dangerous. we could just return a ref to _variableDatums
 {
-    return _variableDatumBits;
+    return _variableDatums.data();
 }
 
-void VariableDatum::setVariableDatumBits(unsigned int pX)
+const char* VariableDatum::getVariableDatums() const
 {
-    _variableDatumBits = pX;
+    return _variableDatums.data();
 }
 
-unsigned int VariableDatum::getPadding() const
+void VariableDatum::setVariableDatums(const char* x, const unsigned int length)
 {
-    return _padding;
-}
+    // convert and store length as bits
+    _variableDatumLength = length * 8;
 
-void VariableDatum::setPadding(unsigned int pX)
-{
-    _padding = pX;
+    // Figure out _arrayLength (including padding to force whole 8 byte chunks)
+    unsigned int chunks = length / 8;
+    int remainder = length % 8;
+    if(remainder > 0)
+		chunks++;
+    _arrayLength = chunks * 8;
+
+    // .resize() might (theoretically) throw. want to catch? : what to do? zombie datum?
+    if(_variableDatums.size() < length)
+        _variableDatums.resize(length);
+
+    for(unsigned int i = 0; i < length; i++)
+    {
+        _variableDatums[i] = x[i];
+    }
+    for(unsigned long i = length; i < _variableDatums.size(); i++)
+    {
+        _variableDatums[i] = 0;
+    }
 }
 
 void VariableDatum::marshal(DataStream& dataStream) const
 {
     dataStream << _variableDatumID;
-    dataStream << ( unsigned int )_variableDatums.size() * 64;
+    dataStream << _variableDatumLength;
 
-     for(size_t idx = 0; idx < _variableDatums.size(); idx++)
-     {
-        EightByteChunk x = _variableDatums[idx];
-        x.marshal(dataStream);
-     }
+    for(unsigned int idx = 0; idx < _arrayLength; idx++)
+    {
+        dataStream << _variableDatums[idx];
+    }
 
 }
 
@@ -72,39 +87,61 @@ void VariableDatum::unmarshal(DataStream& dataStream)
 {
     dataStream >> _variableDatumID;
     dataStream >> _variableDatumLength;
-    _variableDatumLength = (_variableDatumLength / 64) + ((_variableDatumLength % 64) > 0);
 
-     _variableDatums.clear();
-     for(size_t idx = 0; idx < _variableDatumLength; idx++)
+    int byteLength = _variableDatumLength / 8;
+	int chunks = byteLength / 8;
+	if(byteLength % 8 > 0)
+		chunks++;
+	_arrayLength = chunks * 8;
+
+	//std::cout << "Variable datum #" << (int)_variableDatumID << " arrayLength=" << (int)_arrayLength << " ";
+
+    // .resize() might (theoretically) throw. want to catch? : what to do? zombie datum?
+    if(_variableDatums.size() < _arrayLength)
+        _variableDatums.resize(_arrayLength);
+
+     for(unsigned int idx = 0; idx < _arrayLength; idx++)
      {
-        EightByteChunk x;
-        x.unmarshal(dataStream);
-        _variableDatums.push_back(x);
+        dataStream >> _variableDatums[idx];
+		//std::cout << (int)_variableDatums[idx] << " ";
      }
+	 //std::cout << std::endl;
+     for(unsigned long long idx = _arrayLength; idx < _variableDatums.size(); idx++)
+	 {
+		 _variableDatums[idx] = 0;
+	 }
+	 //std::cout << " Created and copied data to new _variableDatums array" << std::endl;
+
 }
 
 
 bool VariableDatum::operator ==(const VariableDatum& rhs) const
  {
-     bool ivarsEqual = true;
+    bool ivarsEqual = true;
 
-     if( ! (_variableDatumID == rhs._variableDatumID) ) ivarsEqual = false;
-     if( ! (_variableDatumLength == rhs._variableDatumLength) ) ivarsEqual = false;
-     if( ! (_variableDatumBits == rhs._variableDatumBits) ) ivarsEqual = false;
-     if( ! (_padding == rhs._padding) ) ivarsEqual = false;
+    if( ! (_variableDatumID == rhs._variableDatumID) ) ivarsEqual = false;
+    if( ! (_variableDatumLength == rhs._variableDatumLength) ) ivarsEqual = false;
+    if( ! (_variableDatums.size() == rhs._variableDatums.size()) ) ivarsEqual = false;
+    else {
+        for(std::size_t idx = 0; idx < _variableDatums.size(); idx++)
+        {
+            if(!(_variableDatums[idx] == rhs._variableDatums[idx]) ) {ivarsEqual = false; break; }
+        }
+    }
 
     return ivarsEqual;
  }
 
 int VariableDatum::getMarshalledSize() const
 {
-   int marshalSize = 0;
+    unsigned int marshalSize = 0;
 
-   marshalSize = marshalSize + 4;  // _variableDatumID
-   marshalSize = marshalSize + 4;  // _variableDatumLength
-   marshalSize = marshalSize + 4;  // _variableDatumBits
-   marshalSize = marshalSize + 4;  // _padding
-    return marshalSize;
+    marshalSize = marshalSize + 4;  // _variableDatumID
+    marshalSize = marshalSize + 4;  // _variableDatumLength
+
+     marshalSize = marshalSize + _arrayLength;
+
+     return marshalSize;
 }
 
 // Copyright (c) 1995-2009 held by the author(s).  All rights reserved.

--- a/src/dis7/VariableDatum.h
+++ b/src/dis7/VariableDatum.h
@@ -5,6 +5,7 @@
 #include <dis7/EightByteChunk.h>
 #include <vector>
 
+#define STATIC_ARRAY_LENGTH 128
 
 namespace DIS
 {
@@ -21,17 +22,11 @@ protected:
   unsigned int _variableDatumID; 
 
   /** Length, in bits, of the variable datum. */
-  unsigned int _variableDatumLength; 
+  unsigned int _variableDatumLength;
 
-  /** Variable datum. This can be any number of bits long, depending on the datum. */
-  unsigned int _variableDatumBits; 
-
-  /** padding to put the record on a 64 bit boundary */
-  unsigned int _padding; 
-
-  // Variable Data
-  std::vector<EightByteChunk> _variableDatums;
-
+  /** The variable datum data.*/
+  std::vector<char> _variableDatums;
+  unsigned int _arrayLength;
 
  public:
     VariableDatum();
@@ -46,12 +41,9 @@ protected:
     unsigned int getVariableDatumLength() const; 
     void setVariableDatumLength(unsigned int pX); 
 
-    unsigned int getVariableDatumBits() const; 
-    void setVariableDatumBits(unsigned int pX); 
-
-    unsigned int getPadding() const; 
-    void setPadding(unsigned int pX); 
-
+    char*  getVariableDatums();
+    const char*  getVariableDatums() const;
+    void setVariableDatums(const char* pX, const unsigned int length);
 
 virtual int getMarshalledSize() const;
 


### PR DESCRIPTION
Fix problems with `src/dis7/VariableDatum.*`. There is currently no way of setting member `_variableDatums`. This pr is fix that uses  working implementation from `src/dis6/VariableDatum.*`

