### PR TITLE
Align CMake Version in Examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 project(OpenDIS-Examples VERSION 1.0.0)
 
 # include GNUInstallDirs Module to get more generic directory handling


### PR DESCRIPTION
Lift CMake minimim version of Examples from 3.2 to 3.5, same as in top CMake. This avoids following error: 

```
CMake Error at examples/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.`
```